### PR TITLE
Add playing time analytics reporting across desktop and web

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,8 @@
   <div class="toolbar">
     <button class="btn" id="btnSetup">Setup</button>
     <button class="btn" id="btnLineup">Lineup</button>
-    <button class="btn primary" id="btnGame">Game</button>
+    <button class="btn" id="btnGame">Game</button>
+    <button class="btn" id="btnReports">Reports</button>
   </div>
 </header>
 
@@ -106,10 +107,29 @@
           <button class="btn" id="btnEndHalftime">Force End Halftime</button>
         </div>
         <div class="divider"></div>
+        <div class="section-title">Timer Configuration</div>
         <div class="row">
-          <label>Adjust Elapsed (+/- sec):</label>
-          <input id="adjustSec" placeholder="e.g. -30" style="max-width:120px" />
-          <button class="btn" id="btnAdjust">Apply</button>
+          <label>Regulation Minutes:</label>
+          <input id="formatMinutes" type="number" min="10" max="120" step="5" style="max-width:120px" />
+          <label>Periods:</label>
+          <select id="formatPeriods" style="max-width:140px">
+            <option value="1">1 Full Time</option>
+            <option value="2" selected>2 Halves</option>
+            <option value="3">3 Thirds</option>
+            <option value="4">4 Quarters</option>
+          </select>
+          <button class="btn" id="btnApplyFormat">Apply Format</button>
+        </div>
+        <div class="row" style="margin-top:8px">
+          <label>Manual Time:</label>
+          <select id="adjustKind" style="max-width:180px">
+            <option value="adjustment">Adjustment (+/-)</option>
+            <option value="stoppage">Stoppage / Injury</option>
+          </select>
+          <select id="adjustPeriod" style="max-width:160px"></select>
+          <input id="adjustSeconds" placeholder="Seconds" style="max-width:120px" />
+          <label class="hint"><input type="checkbox" id="adjustAll" style="margin-right:4px" />All periods</label>
+          <button class="btn" id="btnApplyManual">Apply</button>
         </div>
         <p class="hint">Tip: Save at kickoff, halftime, and full time. State also persists in your browser (localStorage).</p>
       </div>
@@ -154,7 +174,9 @@
       <div class="row" style="gap:12px">
         <div class="pill" id="clockLabel">00:00 / 60:00</div>
         <div class="pill" id="statusLabel">PAUSED</div>
-        <div class="pill" id="halfLabel" style="display:none">HALFTIME</div>
+        <div class="pill" id="periodPill">1st Half</div>
+        <div class="pill" id="metaPill">Stoppage 00:00 • Adjust +00:00</div>
+        <div class="pill" id="halfLabel" style="display:none">BREAK</div>
         <div class="pill" id="schedLabel" style="display:none">Starts in 00:00</div>
       </div>
       <div class="row">
@@ -163,6 +185,16 @@
         <button class="btn" id="gHalf">Halftime (10.5m)</button>
         <button class="btn" id="gSave">Save</button>
       </div>
+    </div>
+
+    <div class="panel" style="margin-top:12px">
+      <div class="section-title">Period Summary</div>
+      <table id="periodTable">
+        <thead>
+          <tr><th>Period</th><th>Reg</th><th>Elapsed</th><th>Adj</th><th>Stop</th><th>Remain</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
     </div>
 
     <div class="grid cols-2" style="margin-top:12px">
@@ -197,6 +229,41 @@
     </div>
   </section>
 
+  <!-- Reports -->
+  <section class="panel hidden" id="viewReports">
+    <div class="section-title">4) Playing Time Analytics</div>
+    <div class="grid cols-2">
+      <div class="panel" style="min-height:120px">
+        <div class="section-title">Summary</div>
+        <p class="accent" id="reportSummary">Add players to view analytics.</p>
+        <p class="hint" id="reportDetail"></p>
+        <p class="hint" id="reportDistribution"></p>
+      </div>
+      <div class="panel" style="min-height:120px">
+        <div class="section-title">Targets</div>
+        <p class="hint" id="reportTargets"></p>
+        <p class="hint" id="reportElapsed"></p>
+      </div>
+    </div>
+    <div class="divider"></div>
+    <table id="reportTable">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>#</th>
+          <th>Preferred</th>
+          <th>Status</th>
+          <th>Played</th>
+          <th>Target</th>
+          <th>Delta</th>
+          <th>Share</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <p class="hint" id="reportNote">Delta compares playing time against an equal share of regulation, stoppage, and adjustments.</p>
+  </section>
+
 </div>
 
 <script>
@@ -204,28 +271,147 @@
  *  Data Model & Utilities
  *  ------------------------- */
 const GAME_LENGTH_MIN = 60;
-const EQUAL_TARGET_MIN = 30;
 const HALFTIME_MIN = 10.5;
+const PERIOD_LABELS = {1: "Full Time", 2: "Half", 3: "Third", 4: "Quarter"};
 const REQUIRED_SLOTS = ["GK","DF","DF","DF","MF","MF","ST","ST","ST"];
 const POS_FULL = {GK:"Goalkeeper", DF:"Defender", MF:"Midfielder", ST:"Striker"};
+const FAIRNESS_THRESHOLD = 120; // seconds
 
 let state = {
   players: [], // {name, number, preferred, totalSec, onField, position, stintStart}
   gameStartTs: null,
   paused: true,
+  breakActive: false,
   halftimeEndTs: null,
   scheduledStartTs: null,
-  elapsedAdjustment: 0
+  elapsedAdjustment: 0, // legacy aggregate
+  gameLengthSec: GAME_LENGTH_MIN * 60,
+  periodCount: 2,
+  periodElapsed: [],
+  periodAdjust: [],
+  periodStoppage: [],
+  currentPeriodIndex: 0,
+  periodStartTs: null
 };
+
+function ordinal(n) {
+  const rem100 = n % 100;
+  if (rem100 >= 11 && rem100 <= 13) return `${n}th`;
+  const rem10 = n % 10;
+  const suffix = rem10 === 1 ? "st" : rem10 === 2 ? "nd" : rem10 === 3 ? "rd" : "th";
+  return `${n}${suffix}`;
+}
+
+function describePeriodLabel(number, total) {
+  const base = PERIOD_LABELS[total] || "Period";
+  if (total <= 1) return base;
+  return `${ordinal(number)} ${base}`;
+}
+
+function ensurePeriodArrays() {
+  const count = Math.max(1, state.periodCount | 0);
+  state.periodCount = count;
+  const expand = (arr) => {
+    if (!Array.isArray(arr)) arr = [];
+    if (arr.length < count) {
+      return arr.concat(Array(count - arr.length).fill(0));
+    }
+    if (arr.length > count) {
+      return arr.slice(0, count);
+    }
+    return arr;
+  };
+  state.periodElapsed = expand(state.periodElapsed);
+  state.periodAdjust = expand(state.periodAdjust);
+  state.periodStoppage = expand(state.periodStoppage);
+  if (state.currentPeriodIndex >= count) {
+    state.currentPeriodIndex = count - 1;
+  }
+}
+
+function normalizeState() {
+  state.gameLengthSec = Number(state.gameLengthSec || GAME_LENGTH_MIN * 60);
+  state.periodCount = Number(state.periodCount || 2);
+  state.elapsedAdjustment = Number(state.elapsedAdjustment || 0);
+  if (typeof state.currentPeriodIndex !== "number") state.currentPeriodIndex = 0;
+  if (typeof state.periodStartTs !== "number") state.periodStartTs = null;
+  state.breakActive = Boolean(state.breakActive);
+  ensurePeriodArrays();
+}
+
+function totalAdjustmentSeconds() {
+  ensurePeriodArrays();
+  return state.periodAdjust.slice(0, state.periodCount).reduce((sum, v) => sum + (v | 0), 0);
+}
+
+function recalcAggregateAdjustment() {
+  state.elapsedAdjustment = totalAdjustmentSeconds();
+}
+
+function totalStoppageSeconds() {
+  ensurePeriodArrays();
+  return state.periodStoppage.slice(0, state.periodCount).reduce((sum, v) => sum + (v | 0), 0);
+}
+
+function targetSecondsTotal() {
+  return Math.max(0, state.gameLengthSec + totalStoppageSeconds() + totalAdjustmentSeconds());
+}
+
+function targetSecondsPerPlayer() {
+  const rosterSize = Math.max(1, state.players.length);
+  return targetSecondsTotal() / rosterSize;
+}
+
+function baseElapsedSeconds(includeRunning = true) {
+  ensurePeriodArrays();
+  let total = state.periodElapsed.slice(0, state.periodCount).reduce((sum, v) => sum + (v | 0), 0);
+  if (includeRunning && state.periodStartTs && !state.paused && !state.breakActive) {
+    total += Math.max(0, nowSec() - state.periodStartTs);
+  }
+  if (total === 0 && state.gameStartTs) {
+    total = Math.max(0, nowSec() - state.gameStartTs);
+  }
+  return total;
+}
+
+function gameElapsedSeconds() {
+  return baseElapsedSeconds() + totalAdjustmentSeconds() + totalStoppageSeconds();
+}
+
+function periodTargetSeconds(index) {
+  ensurePeriodArrays();
+  const count = state.periodCount;
+  const base = Math.floor(state.gameLengthSec / count);
+  const remainder = state.gameLengthSec % count;
+  const reg = base + (index < remainder ? 1 : 0);
+  return reg + (state.periodAdjust[index] | 0) + (state.periodStoppage[index] | 0);
+}
+
+function periodRegulationSeconds(index) {
+  const count = state.periodCount;
+  const base = Math.floor(state.gameLengthSec / count);
+  const remainder = state.gameLengthSec % count;
+  return base + (index < remainder ? 1 : 0);
+}
+
+function periodRemainingSeconds(index) {
+  const target = periodTargetSeconds(index);
+  const elapsed = state.periodElapsed[index] + (index === state.currentPeriodIndex && state.periodStartTs && !state.paused && !state.breakActive ? Math.max(0, nowSec() - state.periodStartTs) : 0);
+  return Math.max(0, target - elapsed);
+}
+
+normalizeState();
 
 let ui = {
   // nav
   btnSetup: document.getElementById("btnSetup"),
   btnLineup: document.getElementById("btnLineup"),
   btnGame: document.getElementById("btnGame"),
+  btnReports: document.getElementById("btnReports"),
   viewSetup: document.getElementById("viewSetup"),
   viewLineup: document.getElementById("viewLineup"),
   viewGame: document.getElementById("viewGame"),
+  viewReports: document.getElementById("viewReports"),
 
   // setup
   rosterInput: document.getElementById("rosterInput"),
@@ -242,8 +428,14 @@ let ui = {
   btnPause: document.getElementById("btnPause"),
   btnHalftime: document.getElementById("btnHalftime"),
   btnEndHalftime: document.getElementById("btnEndHalftime"),
-  adjustSec: document.getElementById("adjustSec"),
-  btnAdjust: document.getElementById("btnAdjust"),
+  formatMinutes: document.getElementById("formatMinutes"),
+  formatPeriods: document.getElementById("formatPeriods"),
+  btnApplyFormat: document.getElementById("btnApplyFormat"),
+  adjustKind: document.getElementById("adjustKind"),
+  adjustPeriod: document.getElementById("adjustPeriod"),
+  adjustSeconds: document.getElementById("adjustSeconds"),
+  adjustAll: document.getElementById("adjustAll"),
+  btnApplyManual: document.getElementById("btnApplyManual"),
 
   // lineup
   slotList: document.getElementById("slotList"),
@@ -255,18 +447,30 @@ let ui = {
   // game
   clockLabel: document.getElementById("clockLabel"),
   statusLabel: document.getElementById("statusLabel"),
+  periodPill: document.getElementById("periodPill"),
+  metaPill: document.getElementById("metaPill"),
   halfLabel: document.getElementById("halfLabel"),
   schedLabel: document.getElementById("schedLabel"),
   gStart: document.getElementById("gStart"),
   gPause: document.getElementById("gPause"),
   gHalf: document.getElementById("gHalf"),
   gSave: document.getElementById("gSave"),
+  periodTable: document.querySelector("#periodTable tbody"),
   onFieldTable: document.querySelector("#onFieldTable tbody"),
   rosterGameTable: document.querySelector("#rosterGameTable tbody"),
   btnQueue: document.getElementById("btnQueue"),
   btnClearQueue: document.getElementById("btnClearQueue"),
   btnCommit: document.getElementById("btnCommit"),
   queueList: document.getElementById("queueList"),
+
+  // reports
+  reportSummary: document.getElementById("reportSummary"),
+  reportDetail: document.getElementById("reportDetail"),
+  reportDistribution: document.getElementById("reportDistribution"),
+  reportTargets: document.getElementById("reportTargets"),
+  reportElapsed: document.getElementById("reportElapsed"),
+  reportTable: document.querySelector("#reportTable tbody"),
+  reportNote: document.getElementById("reportNote"),
 };
 
 let selectedSlotIndex = null;  // for lineup
@@ -277,18 +481,49 @@ let tickHandle = null;
 
 function nowSec() { return Math.floor(Date.now()/1000); }
 function fmtMMSS(sec) { sec = Math.max(0, sec|0); const m = Math.floor(sec/60), s = sec%60; return `${String(m).padStart(2,"0")}:${String(s).padStart(2,"0")}`; }
-function saveLocal() { localStorage.setItem("sideline_state", JSON.stringify(state)); }
-function loadLocal() { const s = localStorage.getItem("sideline_state"); if(s){ state = JSON.parse(s); } }
+function fmtSignedMMSS(sec) { const sign = sec >= 0 ? "+" : "-"; return sign + fmtMMSS(Math.abs(sec)); }
+function saveLocal() {
+  recalcAggregateAdjustment();
+  localStorage.setItem("sideline_state", JSON.stringify(state));
+}
+function loadLocal() {
+  const s = localStorage.getItem("sideline_state");
+  if (s) {
+    try {
+      state = JSON.parse(s);
+    } catch (err) {
+      console.warn("Failed to parse saved state", err);
+    }
+  }
+  normalizeState();
+  recalcAggregateAdjustment();
+}
 function resetAll() {
-  state = { players:[], gameStartTs:null, paused:true, halftimeEndTs:null, scheduledStartTs:null, elapsedAdjustment:0 };
+  state = {
+    players: [],
+    gameStartTs: null,
+    paused: true,
+    breakActive: false,
+    halftimeEndTs: null,
+    scheduledStartTs: null,
+    elapsedAdjustment: 0,
+    gameLengthSec: GAME_LENGTH_MIN * 60,
+    periodCount: 2,
+    periodElapsed: [],
+    periodAdjust: [],
+    periodStoppage: [],
+    currentPeriodIndex: 0,
+    periodStartTs: null
+  };
+  normalizeState();
   subQueue = []; selectedOutName = null; selectedInName = null; selectedSlotIndex = null;
   saveLocal(); renderAll();
 }
 
-function fairnessClass(totalSec) {
-  const delta = totalSec - EQUAL_TARGET_MIN*60;
-  if (delta < -180) return "under";
-  if (delta > 180) return "over";
+function fairnessClass(totalSec, targetSec = targetSecondsPerPlayer()) {
+  const delta = totalSec - targetSec;
+  if (delta <= -FAIRNESS_THRESHOLD) return "under";
+  if (delta >= FAIRNESS_THRESHOLD) return "over";
   return "ok";
 }
 
@@ -301,18 +536,46 @@ function totalLive(p) {
   return (p.totalSec|0) + currentStint(p);
 }
 
+function median(values) {
+  if (!values.length) return 0;
+  const sorted = values.slice().sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+  return sorted[mid];
+}
+
 /** -------------------------
  *  Navigation & Views
  *  ------------------------- */
 function show(view) {
-  ui.viewSetup.classList.toggle("hidden", view!=="setup");
-  ui.viewLineup.classList.toggle("hidden", view!=="lineup");
-  ui.viewGame.classList.toggle("hidden", view!=="game");
+  const views = {
+    setup: ui.viewSetup,
+    lineup: ui.viewLineup,
+    game: ui.viewGame,
+    reports: ui.viewReports,
+  };
+  Object.entries(views).forEach(([key, el]) => {
+    if (!el) return;
+    el.classList.toggle("hidden", view !== key);
+  });
+  const buttons = {
+    setup: ui.btnSetup,
+    lineup: ui.btnLineup,
+    game: ui.btnGame,
+    reports: ui.btnReports,
+  };
+  Object.entries(buttons).forEach(([key, btn]) => {
+    if (!btn) return;
+    btn.classList.toggle("primary", view === key);
+  });
 }
 
 ui.btnSetup.onclick = () => { show("setup"); };
 ui.btnLineup.onclick = () => { show("lineup"); renderLineup(); };
 ui.btnGame.onclick = () => { show("game"); renderGame(); };
+ui.btnReports.onclick = () => { show("reports"); renderReports(); };
 
 /** -------------------------
  *  Setup
@@ -400,14 +663,57 @@ ui.btnStart.onclick = startGame;
 ui.btnPause.onclick = pauseGame;
 ui.btnHalftime.onclick = startHalftime;
 ui.btnEndHalftime.onclick = endHalftime;
-
-ui.btnAdjust.onclick = () => {
-  const v = parseInt(ui.adjustSec.value, 10);
-  if (isNaN(v)) return;
-  state.elapsedAdjustment = (state.elapsedAdjustment|0) + v;
+ui.btnApplyFormat.onclick = () => {
+  const minutes = parseInt(ui.formatMinutes.value, 10);
+  const periods = parseInt(ui.formatPeriods.value, 10);
+  if (Number.isNaN(minutes) || Number.isNaN(periods)) { alert("Enter minutes and period count."); return; }
+  if (minutes < 10 || minutes > 120) { alert("Minutes must be between 10 and 120."); return; }
+  if (periods < 1 || periods > 4) { alert("Periods must be between 1 and 4."); return; }
+  if (minutes * 60 < periods * 60) { alert("Provide at least one minute per period."); return; }
+  if (state.gameStartTs) { alert("Stop/reset the game before changing the timer format."); return; }
+  state.gameLengthSec = minutes * 60;
+  state.periodCount = periods;
+  ensurePeriodArrays();
+  state.periodElapsed = Array(periods).fill(0);
+  state.periodAdjust = Array(periods).fill(0);
+  state.periodStoppage = Array(periods).fill(0);
+  state.currentPeriodIndex = 0;
+  state.periodStartTs = null;
+  recalcAggregateAdjustment();
   saveLocal();
-  ui.adjustSec.value = "";
-  renderGame();
+  renderAll();
+};
+
+ui.adjustKind.onchange = () => {
+  const isStoppage = ui.adjustKind.value === "stoppage";
+  ui.adjustAll.disabled = isStoppage;
+  if (isStoppage) ui.adjustAll.checked = false;
+};
+
+ui.btnApplyManual.onclick = () => {
+  ensurePeriodArrays();
+  const kind = ui.adjustKind.value;
+  const periodIndex = parseInt(ui.adjustPeriod.value, 10);
+  const seconds = parseInt(ui.adjustSeconds.value, 10);
+  if (Number.isNaN(periodIndex)) { alert("Select a period."); return; }
+  if (Number.isNaN(seconds)) { alert("Enter seconds (integer)."); return; }
+  if (kind === "adjustment") {
+    if (seconds === 0) { alert("Enter a non-zero adjustment."); return; }
+    if (ui.adjustAll.checked) {
+      for (let i = 0; i < state.periodCount; i++) {
+        state.periodAdjust[i] += seconds;
+      }
+    } else {
+      state.periodAdjust[periodIndex] += seconds;
+    }
+    recalcAggregateAdjustment();
+  } else {
+    if (seconds <= 0) { alert("Stoppage time must be positive seconds."); return; }
+    state.periodStoppage[periodIndex] = Math.max(0, state.periodStoppage[periodIndex] + seconds);
+  }
+  ui.adjustSeconds.value = "";
+  saveLocal();
+  renderAll();
 };
 
 /** -------------------------
@@ -494,7 +800,15 @@ ui.btnStartGame.onclick = () => {
       if (p) { p.onField = true; p.position = pos; p.stintStart = n; }
     }
   }
-  if (!state.gameStartTs) state.gameStartTs = n;
+  const firstStart = !state.gameStartTs;
+  if (firstStart) state.gameStartTs = n;
+  ensurePeriodArrays();
+  if (firstStart) {
+    state.currentPeriodIndex = 0;
+    state.periodElapsed = Array(state.periodCount).fill(0);
+  }
+  state.periodStartTs = n;
+  state.breakActive = false;
   state.paused = false;
   saveLocal();
   show("game");
@@ -506,10 +820,19 @@ ui.btnStartGame.onclick = () => {
  *  Game
  *  ------------------------- */
 function startGame() {
+  ensurePeriodArrays();
   const n = nowSec();
-  if (!state.gameStartTs) state.gameStartTs = n;
+  const firstStart = !state.gameStartTs;
+  if (firstStart) {
+    state.gameStartTs = n;
+    state.currentPeriodIndex = 0;
+    state.periodElapsed = Array(state.periodCount).fill(0);
+  }
+  if (!state.periodStartTs || state.paused || state.breakActive) {
+    state.periodStartTs = n;
+  }
+  state.breakActive = false;
   state.paused = false;
-  // resume any paused stints (stintStart null means paused)
   state.players.forEach(p=>{
     if (p.onField && !p.stintStart) p.stintStart = n;
   });
@@ -521,6 +844,11 @@ function startGame() {
 function pauseGame() {
   if (state.paused) return;
   const n = nowSec();
+  ensurePeriodArrays();
+  if (state.periodStartTs) {
+    state.periodElapsed[state.currentPeriodIndex] += Math.max(0, n - state.periodStartTs);
+    state.periodStartTs = null;
+  }
   state.players.forEach(p=>{
     if (p.onField && p.stintStart) {
       p.totalSec += (n - p.stintStart);
@@ -535,6 +863,7 @@ function pauseGame() {
 
 function startHalftime() {
   pauseGame();
+  state.breakActive = true;
   state.halftimeEndTs = nowSec() + Math.floor(HALFTIME_MIN*60);
   saveLocal();
   renderGame();
@@ -542,9 +871,22 @@ function startHalftime() {
 }
 
 function endHalftime() {
+  ensurePeriodArrays();
+  state.breakActive = false;
   state.halftimeEndTs = null;
+  if (state.currentPeriodIndex < state.periodCount - 1) {
+    state.currentPeriodIndex += 1;
+  }
+  const n = nowSec();
+  state.periodStartTs = n;
+  state.paused = false;
+  if (!state.gameStartTs) state.gameStartTs = n;
+  state.players.forEach(p=>{
+    if (p.onField && !p.stintStart) p.stintStart = n;
+  });
   saveLocal();
   renderGame();
+  startTick();
 }
 
 ui.gStart.onclick = startGame;
@@ -552,34 +894,67 @@ ui.gPause.onclick = pauseGame;
 ui.gHalf.onclick = startHalftime;
 ui.gSave.onclick = () => ui.btnSave.click();
 
-function elapsedSeconds() {
-  if (!state.gameStartTs) return 0;
-  const base = nowSec() - state.gameStartTs;
-  return Math.max(0, base + (state.elapsedAdjustment|0));
-}
-
 function renderGame() {
-  // top labels
-  if (state.halftimeEndTs && nowSec() <= state.halftimeEndTs) {
-    const remain = Math.max(0, state.halftimeEndTs - nowSec());
-    ui.clockLabel.textContent = `HALFTIME ${fmtMMSS(remain)}`;
-    ui.halfLabel.style.display = "";
+  ensurePeriodArrays();
+  const elapsed = gameElapsedSeconds();
+  const target = state.gameLengthSec + totalStoppageSeconds();
+  ui.clockLabel.textContent = `${fmtMMSS(elapsed)} / ${fmtMMSS(target)}`;
+  ui.statusLabel.textContent = state.paused ? "PAUSED" : "RUNNING";
+
+  const periodLabel = describePeriodLabel(state.currentPeriodIndex + 1, state.periodCount);
+  ui.periodPill.textContent = `${periodLabel} (${state.currentPeriodIndex + 1}/${state.periodCount})`;
+  ui.metaPill.textContent = `Stoppage ${fmtMMSS(totalStoppageSeconds())} • Adjust ${fmtSignedMMSS(totalAdjustmentSeconds())}`;
+
+  if (state.breakActive) {
+    if (state.halftimeEndTs && nowSec() <= state.halftimeEndTs) {
+      const remain = Math.max(0, state.halftimeEndTs - nowSec());
+      ui.halfLabel.style.display = "";
+      ui.halfLabel.textContent = `BREAK ${fmtMMSS(remain)}`;
+    } else {
+      ui.halfLabel.style.display = "";
+      ui.halfLabel.textContent = "BREAK";
+    }
   } else {
     ui.halfLabel.style.display = "none";
-    ui.clockLabel.textContent = `${fmtMMSS(elapsedSeconds())} / ${fmtMMSS(GAME_LENGTH_MIN*60)}`;
   }
-  ui.statusLabel.textContent = state.paused ? "PAUSED" : "RUNNING";
 
   if (state.scheduledStartTs && !state.gameStartTs) {
     const delta = state.scheduledStartTs - nowSec();
     if (delta > 0) {
-      ui.schedLabel.style.display = ""; ui.schedLabel.textContent = `Starts in ${fmtMMSS(delta)}`;
+      ui.schedLabel.style.display = "";
+      ui.schedLabel.textContent = `Starts in ${fmtMMSS(delta)}`;
     } else {
-      ui.schedLabel.style.display = ""; ui.schedLabel.textContent = `Starting…`;
+      ui.schedLabel.style.display = "";
+      ui.schedLabel.textContent = `Starting…`;
       startGame();
     }
   } else {
     ui.schedLabel.style.display = "none";
+  }
+
+  ui.periodTable.innerHTML = "";
+  const now = nowSec();
+  for (let i = 0; i < state.periodCount; i++) {
+    const running = (i === state.currentPeriodIndex && state.periodStartTs && !state.paused && !state.breakActive)
+      ? Math.max(0, now - state.periodStartTs)
+      : 0;
+    const elapsedReg = (state.periodElapsed[i] || 0) + running;
+    const adjust = state.periodAdjust[i] || 0;
+    const stoppage = state.periodStoppage[i] || 0;
+    const remain = periodRemainingSeconds(i);
+    const tr = document.createElement("tr");
+    if (i === state.currentPeriodIndex && !state.breakActive) {
+      tr.style.fontWeight = "600";
+    }
+    tr.innerHTML = `
+      <td>${describePeriodLabel(i + 1, state.periodCount)}</td>
+      <td>${fmtMMSS(periodRegulationSeconds(i))}</td>
+      <td>${fmtMMSS(elapsedReg)}</td>
+      <td>${fmtSignedMMSS(adjust)}</td>
+      <td>${fmtMMSS(stoppage)}</td>
+      <td>${fmtMMSS(remain)}</td>
+    `;
+    ui.periodTable.appendChild(tr);
   }
 
   // On-field table
@@ -635,6 +1010,8 @@ function renderGame() {
       <button class="btn" onclick="removeQueue(${i})">Remove</button>`;
     ui.queueList.appendChild(li);
   });
+
+  renderReports();
 }
 
 function highlightSelections() {
@@ -693,13 +1070,86 @@ function startTick() {
     // halftime countdown end
     if (state.halftimeEndTs && nowSec() >= state.halftimeEndTs) {
       state.halftimeEndTs = null;
+      state.breakActive = false;
       saveLocal();
       alert("Halftime complete. Press Start/Resume to continue.");
     }
     renderGame();
+    renderReports();
   }, 1000);
 }
 function stopTick(){ if (tickHandle) { clearInterval(tickHandle); tickHandle = null; } }
+
+function renderReports() {
+  if (!ui.reportSummary) return;
+  ensurePeriodArrays();
+
+  const roster = state.players.slice();
+  if (!roster.length) {
+    ui.reportSummary.textContent = "Add players to view analytics.";
+    ui.reportDetail.textContent = "";
+    ui.reportDistribution.textContent = "";
+    ui.reportTargets.textContent = "";
+    ui.reportElapsed.textContent = "";
+    ui.reportTable.innerHTML = "";
+    return;
+  }
+
+  const elapsed = gameElapsedSeconds();
+  const totalTarget = Math.round(targetSecondsTotal());
+  const perPlayerTarget = targetSecondsPerPlayer();
+  const perPlayerRounded = Math.round(perPlayerTarget);
+  const stoppage = totalStoppageSeconds();
+  const adjustments = totalAdjustmentSeconds();
+
+  ui.reportSummary.textContent = `Elapsed ${fmtMMSS(elapsed)} / Target ${fmtMMSS(totalTarget)} — ${roster.length} players`;
+  ui.reportDetail.textContent = `Regulation ${fmtMMSS(state.gameLengthSec)} • Stoppage ${fmtMMSS(stoppage)} • Adjust ${fmtSignedMMSS(adjustments)}`;
+  ui.reportTargets.textContent = `Per player target ${fmtMMSS(perPlayerRounded)}`;
+  ui.reportElapsed.textContent = `Remaining ${fmtMMSS(Math.max(0, totalTarget - elapsed))}`;
+
+  const totals = roster.map(p => totalLive(p));
+  const average = totals.length ? totals.reduce((sum, value) => sum + value, 0) / totals.length : 0;
+  const med = median(totals);
+  const minVal = totals.length ? Math.min(...totals) : 0;
+  const maxVal = totals.length ? Math.max(...totals) : 0;
+  ui.reportDistribution.textContent = `Average ${fmtMMSS(Math.round(average))} • Median ${fmtMMSS(Math.round(med))} • Range ${fmtMMSS(minVal)}–${fmtMMSS(maxVal)}`;
+
+  const fairnessOrder = {under: 0, ok: 1, over: 2};
+  const rows = roster.map(p => {
+    const total = totalLive(p);
+    const delta = Math.round(total - perPlayerTarget);
+    const fairness = fairnessClass(total, perPlayerTarget);
+    const share = perPlayerTarget > 0 ? (total / perPlayerTarget) * 100 : 0;
+    const status = p.onField ? `On Field${p.position ? ` (${p.position})` : ""}` : "Bench";
+    return { player: p, total, delta, fairness, share, status };
+  });
+
+  rows.sort((a, b) => {
+    if (fairnessOrder[a.fairness] !== fairnessOrder[b.fairness]) {
+      return fairnessOrder[a.fairness] - fairnessOrder[b.fairness];
+    }
+    if (a.delta !== b.delta) return a.delta - b.delta;
+    return a.player.name.localeCompare(b.player.name);
+  });
+
+  ui.reportTable.innerHTML = "";
+  rows.forEach(row => {
+    const tr = document.createElement("tr");
+    const preferred = (row.player.preferred || "").toUpperCase();
+    const shareText = `${row.share.toFixed(1)}%`;
+    tr.innerHTML = `
+      <td>${row.player.name}</td>
+      <td>${row.player.number || ""}</td>
+      <td>${preferred}</td>
+      <td>${row.status}</td>
+      <td><span class="fair ${row.fairness}">${fmtMMSS(row.total)}</span></td>
+      <td>${fmtMMSS(perPlayerRounded)}</td>
+      <td><span class="fair ${row.fairness}">${fmtSignedMMSS(row.delta)}</span></td>
+      <td>${shareText}</td>
+    `;
+    ui.reportTable.appendChild(tr);
+  });
+}
 
 /** -------------------------
  *  Setup view secondary render
@@ -713,6 +1163,26 @@ function renderSetup() {
   } else {
     ui.scheduledLabel.textContent = "";
   }
+  ui.formatMinutes.value = Math.round(state.gameLengthSec/60);
+  ui.formatPeriods.value = String(state.periodCount);
+  updatePeriodOptions();
+}
+
+function updatePeriodOptions() {
+  ensurePeriodArrays();
+  ui.adjustPeriod.innerHTML = "";
+  for (let i = 0; i < state.periodCount; i++) {
+    const option = document.createElement("option");
+    option.value = String(i);
+    option.textContent = describePeriodLabel(i + 1, state.periodCount);
+    ui.adjustPeriod.appendChild(option);
+  }
+  if (state.periodCount > 0 && !ui.adjustPeriod.value) {
+    ui.adjustPeriod.value = "0";
+  }
+  if (typeof ui.adjustKind.onchange === "function") {
+    ui.adjustKind.onchange();
+  }
 }
 
 /** -------------------------
@@ -722,6 +1192,7 @@ function renderAll() {
   renderSetup();
   renderLineup();
   renderGame();
+  renderReports();
 }
 loadLocal();
 renderAll();

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -7,8 +7,8 @@ and ensuring equal playing time distribution.
 This package provides both desktop (Tkinter) and web (Flask) interfaces
 for coaches to manage their teams during games.
 """
-from .models import Player, GameState
-from .services import PersistenceService, TimerService
+from .models import GameReport, GameState, Player, PlayerTimeSummary
+from .services import AnalyticsService, PersistenceService, TimerService
 from .ui import create_tkinter_app, run_tkinter_app, create_app, run_web_app
 from .utils import fmt_mmss, now_ts, APP_TITLE
 
@@ -16,7 +16,18 @@ __version__ = "2.0.0"
 __author__ = "Soccer Coach Development Team"
 
 __all__ = [
-    "Player", "GameState", "PersistenceService", "TimerService",
-    "create_tkinter_app", "run_tkinter_app", "create_app", "run_web_app",
-    "fmt_mmss", "now_ts", "APP_TITLE"
+    "Player",
+    "GameState",
+    "PlayerTimeSummary",
+    "GameReport",
+    "PersistenceService",
+    "TimerService",
+    "AnalyticsService",
+    "create_tkinter_app",
+    "run_tkinter_app",
+    "create_app",
+    "run_web_app",
+    "fmt_mmss",
+    "now_ts",
+    "APP_TITLE",
 ]

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -5,5 +5,6 @@ This package contains the core data models used throughout the application.
 """
 from .player import Player
 from .game_state import GameState
+from .game_report import GameReport, PlayerTimeSummary
 
-__all__ = ["Player", "GameState"]
+__all__ = ["Player", "GameState", "GameReport", "PlayerTimeSummary"]

--- a/src/models/game_report.py
+++ b/src/models/game_report.py
@@ -1,0 +1,42 @@
+"""Dataclasses representing analytics reports for the timekeeper app."""
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class PlayerTimeSummary:
+    """Aggregated playing time information for a single player."""
+
+    name: str
+    number: Optional[str]
+    preferred_positions: List[str]
+    on_field: bool
+    position: Optional[str]
+    total_seconds: int
+    active_stint_seconds: int
+    cumulative_seconds: int
+    target_seconds: int
+    delta_seconds: int
+    bench_seconds: int
+    target_share: float
+    fairness: str
+
+
+@dataclass
+class GameReport:
+    """Snapshot of playing time distribution for the current game state."""
+
+    generated_ts: float
+    roster_size: int
+    regulation_seconds: int
+    stoppage_seconds: int
+    adjustment_seconds: int
+    elapsed_seconds: int
+    target_seconds_total: int
+    target_seconds_per_player: int
+    players: List[PlayerTimeSummary] = field(default_factory=list)
+    average_seconds: float = 0.0
+    median_seconds: float = 0.0
+    min_seconds: int = 0
+    max_seconds: int = 0

--- a/src/models/game_state.py
+++ b/src/models/game_state.py
@@ -5,9 +5,10 @@ This module contains the GameState dataclass which represents the complete
 state of a soccer game, including players, timing, and persistence methods.
 """
 from dataclasses import dataclass, field, asdict
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from .player import Player
+from ..utils import DEFAULT_GAME_LENGTH_MIN, DEFAULT_PERIOD_COUNT
 
 
 @dataclass
@@ -22,7 +23,14 @@ class GameState:
         paused: Whether the game is currently paused
         halftime_started: Whether halftime has begun
         halftime_end_ts: When halftime will end (epoch seconds)
-        elapsed_adjustment: Manual time adjustments in seconds
+        elapsed_adjustment: Manual time adjustments in seconds (legacy aggregate)
+        game_length_seconds: Configured regulation game length (without stoppage)
+        period_count: Number of regulation periods in the game
+        period_elapsed: Accumulated regulation seconds played per period
+        period_adjustments: Manual adjustments applied per period
+        period_stoppage: Stoppage/injury time tracked per period
+        current_period_index: Index of active period (0-based)
+        period_start_ts: Epoch timestamp when the current period started/resumed
     """
     roster: Dict[str, Player] = field(default_factory=dict)  # key by name (unique)
     # game timing
@@ -32,6 +40,13 @@ class GameState:
     halftime_started: bool = False
     halftime_end_ts: Optional[float] = None
     elapsed_adjustment: int = 0  # manual adjustments if needed
+    game_length_seconds: int = DEFAULT_GAME_LENGTH_MIN * 60
+    period_count: int = DEFAULT_PERIOD_COUNT
+    period_elapsed: List[int] = field(default_factory=list)
+    period_adjustments: List[int] = field(default_factory=list)
+    period_stoppage: List[int] = field(default_factory=list)
+    current_period_index: int = 0
+    period_start_ts: Optional[float] = None
 
     def to_json(self) -> dict:
         """
@@ -48,6 +63,13 @@ class GameState:
             "halftime_started": self.halftime_started,
             "halftime_end_ts": self.halftime_end_ts,
             "elapsed_adjustment": self.elapsed_adjustment,
+            "game_length_seconds": self.game_length_seconds,
+            "period_count": self.period_count,
+            "period_elapsed": list(self.period_elapsed),
+            "period_adjustments": list(self.period_adjustments),
+            "period_stoppage": list(self.period_stoppage),
+            "current_period_index": self.current_period_index,
+            "period_start_ts": self.period_start_ts,
         }
 
     @staticmethod
@@ -70,5 +92,55 @@ class GameState:
         gs.paused = data.get("paused", True)
         gs.halftime_started = data.get("halftime_started", False)
         gs.halftime_end_ts = data.get("halftime_end_ts")
-        gs.elapsed_adjustment = int(data.get("elapsed_adjustment", 0))
+        legacy_adjustment = int(data.get("elapsed_adjustment", 0))
+        gs.elapsed_adjustment = legacy_adjustment
+
+        gs.game_length_seconds = int(
+            data.get(
+                "game_length_seconds",
+                int(data.get("game_length_min", DEFAULT_GAME_LENGTH_MIN)) * 60,
+            )
+        )
+        gs.period_count = max(1, int(data.get("period_count", DEFAULT_PERIOD_COUNT)))
+
+        def _to_int_list(key: str) -> List[int]:
+            raw = data.get(key, []) or []
+            return [int(value) for value in raw]
+
+        gs.period_elapsed = _to_int_list("period_elapsed")
+        gs.period_adjustments = _to_int_list("period_adjustments")
+        gs.period_stoppage = _to_int_list("period_stoppage")
+
+        # Backward compatibility – older saves only tracked aggregate adjustments
+        if not gs.period_adjustments and legacy_adjustment:
+            gs.period_adjustments = [legacy_adjustment]
+
+        gs.current_period_index = int(data.get("current_period_index", 0))
+        gs.period_start_ts = data.get("period_start_ts")
+
+        gs.ensure_timer_lists()
+        # Keep aggregate adjustment in sync with per-period values
+        gs.elapsed_adjustment = sum(gs.period_adjustments[: gs.period_count])
         return gs
+
+    def ensure_timer_lists(self) -> None:
+        """Ensure period-related lists match the configured period count."""
+
+        self.period_count = max(1, self.period_count)
+
+        def _normalize_list(values: List[int]) -> List[int]:
+            if len(values) < self.period_count:
+                values = values + [0] * (self.period_count - len(values))
+            elif len(values) > self.period_count:
+                values = values[: self.period_count]
+            return values
+
+        self.period_elapsed = _normalize_list(self.period_elapsed)
+        self.period_adjustments = _normalize_list(self.period_adjustments)
+        self.period_stoppage = _normalize_list(self.period_stoppage)
+
+        if self.current_period_index >= self.period_count:
+            self.current_period_index = self.period_count - 1
+
+        # Ensure timer fields are non-negative integers where applicable
+        self.game_length_seconds = max(60, int(self.game_length_seconds or 0))

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -5,5 +5,6 @@ This package contains service classes that handle business logic.
 """
 from .persistence_service import PersistenceService
 from .timer_service import TimerService
+from .analytics_service import AnalyticsService
 
-__all__ = ["PersistenceService", "TimerService"]
+__all__ = ["PersistenceService", "TimerService", "AnalyticsService"]

--- a/src/services/analytics_service.py
+++ b/src/services/analytics_service.py
@@ -1,0 +1,125 @@
+"""Analytics helpers for the Soccer Coach Sideline Timekeeper."""
+
+from __future__ import annotations
+
+import statistics
+from typing import List, Optional
+
+from ..models import GameReport, GameState, Player, PlayerTimeSummary
+from ..utils import now_ts
+from .timer_service import TimerService
+
+FAIRNESS_THRESHOLD_SECONDS = 120  # +/- 2 minutes regarded as notable variance
+FAIRNESS_ORDER = {"under": 0, "ok": 1, "over": 2}
+
+
+class AnalyticsService:
+    """Generate reports describing playing time distribution."""
+
+    def __init__(
+        self,
+        game_state: GameState,
+        timer_service: Optional[TimerService] = None,
+    ) -> None:
+        self.game_state = game_state
+        self._timer_service = timer_service
+
+    def set_timer_service(self, timer_service: TimerService) -> None:
+        """Attach a timer service instance used for elapsed time queries."""
+
+        self._timer_service = timer_service
+
+    def _timer(self) -> TimerService:
+        if self._timer_service is None:
+            self._timer_service = TimerService(self.game_state)
+        return self._timer_service
+
+    def generate_game_report(self) -> GameReport:
+        """Build a :class:`GameReport` snapshot for the active game."""
+
+        timer = self._timer()
+        config = timer.get_timer_configuration()
+
+        regulation_seconds = int(config["game_length_seconds"])
+        stoppage_seconds = int(config["total_stoppage_seconds"])
+        adjustment_seconds = int(config["total_adjustment_seconds"])
+        elapsed_seconds = int(timer.get_game_elapsed_seconds())
+
+        roster: List[Player] = list(self.game_state.roster.values())
+        roster_size = len(roster)
+
+        target_total = max(0, regulation_seconds + stoppage_seconds + adjustment_seconds)
+        target_per_player = target_total / roster_size if roster_size else 0.0
+        target_per_player_int = int(round(target_per_player)) if roster_size else 0
+
+        now = now_ts()
+        summaries: List[PlayerTimeSummary] = []
+
+        for player in roster:
+            stint_seconds = player.current_stint_seconds(now)
+            cumulative = player.total_seconds + stint_seconds
+            delta = int(round(cumulative - target_per_player))
+            fairness = self._classify_fairness(delta)
+            bench_seconds = 0
+            if elapsed_seconds > 0:
+                bench_seconds = max(0, int(elapsed_seconds - cumulative))
+
+            target_share = (
+                cumulative / target_per_player if target_per_player > 0 else 0.0
+            )
+
+            summaries.append(
+                PlayerTimeSummary(
+                    name=player.name,
+                    number=player.number,
+                    preferred_positions=player.preferred_list(),
+                    on_field=player.on_field,
+                    position=player.position,
+                    total_seconds=player.total_seconds,
+                    active_stint_seconds=stint_seconds,
+                    cumulative_seconds=cumulative,
+                    target_seconds=target_per_player_int,
+                    delta_seconds=delta,
+                    bench_seconds=bench_seconds,
+                    target_share=target_share,
+                    fairness=fairness,
+                )
+            )
+
+        summaries.sort(
+            key=lambda item: (
+                FAIRNESS_ORDER.get(item.fairness, 1),
+                item.delta_seconds,
+                item.name,
+            )
+        )
+        totals = [summary.cumulative_seconds for summary in summaries]
+
+        average_seconds = statistics.mean(totals) if totals else 0.0
+        median_seconds = statistics.median(totals) if totals else 0.0
+        min_seconds = min(totals) if totals else 0
+        max_seconds = max(totals) if totals else 0
+
+        return GameReport(
+            generated_ts=now,
+            roster_size=roster_size,
+            regulation_seconds=regulation_seconds,
+            stoppage_seconds=stoppage_seconds,
+            adjustment_seconds=adjustment_seconds,
+            elapsed_seconds=elapsed_seconds,
+            target_seconds_total=int(target_total),
+            target_seconds_per_player=target_per_player_int,
+            players=summaries,
+            average_seconds=average_seconds,
+            median_seconds=median_seconds,
+            min_seconds=min_seconds,
+            max_seconds=max_seconds,
+        )
+
+    @staticmethod
+    def _classify_fairness(delta_seconds: int) -> str:
+        if delta_seconds <= -FAIRNESS_THRESHOLD_SECONDS:
+            return "under"
+        if delta_seconds >= FAIRNESS_THRESHOLD_SECONDS:
+            return "over"
+        return "ok"

--- a/src/services/timer_service.py
+++ b/src/services/timer_service.py
@@ -1,194 +1,364 @@
-"""
-Timer service for the Soccer Coach Sideline Timekeeper application.
+"""Timer service for the Soccer Coach Sideline Timekeeper application."""
 
-This module handles game timing logic, including start/pause/resume functionality
-and halftime management.
-"""
-from typing import Optional, Tuple
+from typing import Dict, List, Optional, Tuple
+
 from ..models import GameState
-from ..utils import now_ts, GAME_LENGTH_MIN, HALFTIME_PAUSE_MIN
+from ..utils import now_ts, HALFTIME_PAUSE_MIN
 
 
 class TimerService:
-    """
-    Service for managing game timing and state transitions.
-    
-    This service handles the complexities of soccer game timing including
-    regular time, halftime, and manual adjustments.
-    """
+    """Service for managing game timing, periods, and adjustments."""
 
     def __init__(self, game_state: GameState):
-        """
-        Initialize timer service with game state.
-        
-        Args:
-            game_state: The game state to manage
-        """
         self.game_state = game_state
+        self.game_state.ensure_timer_lists()
 
+        # Backfill legacy states that only tracked a game start timestamp
+        if (
+            self.game_state.game_start_ts is not None
+            and sum(self.game_state.period_elapsed) == 0
+        ):
+            elapsed = max(0, int(now_ts() - self.game_state.game_start_ts))
+            index = min(self.game_state.current_period_index, self.game_state.period_count - 1)
+            self.game_state.period_elapsed[index] = elapsed
+            if not self.game_state.paused and not self.game_state.halftime_started:
+                self.game_state.period_start_ts = now_ts()
+
+    # ------------------------------------------------------------------
+    # Configuration helpers
+    # ------------------------------------------------------------------
+    def configure_game(
+        self,
+        *,
+        game_length_minutes: Optional[int] = None,
+        period_count: Optional[int] = None,
+    ) -> None:
+        """Configure regulation game length and number of periods.
+
+        Raises:
+            ValueError: If attempting to reconfigure after the game has started
+                        or with invalid values.
+        """
+
+        if self.game_state.game_start_ts is not None:
+            raise ValueError("Cannot configure timer after the game has started")
+
+        minutes = (
+            int(game_length_minutes)
+            if game_length_minutes is not None
+            else self.game_state.game_length_seconds // 60
+        )
+        periods = (
+            int(period_count)
+            if period_count is not None
+            else self.game_state.period_count
+        )
+
+        minutes = max(1, minutes)
+        periods = max(1, periods)
+
+        total_seconds = minutes * 60
+        if total_seconds < periods * 60:
+            raise ValueError("Game length must allocate at least 60 seconds per period")
+
+        self.game_state.game_length_seconds = total_seconds
+        self.game_state.period_count = periods
+        self.game_state.period_elapsed = [0] * periods
+        self.game_state.period_adjustments = [0] * periods
+        self.game_state.period_stoppage = [0] * periods
+        self.game_state.current_period_index = 0
+        self.game_state.period_start_ts = None
+        self.game_state.elapsed_adjustment = 0
+        self.game_state.ensure_timer_lists()
+
+    # ------------------------------------------------------------------
+    # Core timer controls
+    # ------------------------------------------------------------------
     def start_game(self) -> None:
-        """
-        Start the game timer.
-        
-        Sets the game start time if not already set and unpauses the game.
-        Resumes any active player stints that were paused.
-        """
+        """Start or resume the game timer."""
+
+        self.game_state.ensure_timer_lists()
+        now = now_ts()
+
         if self.game_state.game_start_ts is None:
-            self.game_state.game_start_ts = now_ts()
+            self.game_state.game_start_ts = now
+            self.game_state.current_period_index = 0
+            self.game_state.period_elapsed = [0] * self.game_state.period_count
+
+        if self.game_state.period_start_ts is None:
+            self.game_state.period_start_ts = now
+
         self.game_state.paused = False
 
     def pause_game(self) -> None:
-        """
-        Pause the game timer.
-        
-        Player stints continue to track but game time stops.
-        """
+        """Pause the game timer and record elapsed time for the active period."""
+
+        if self.game_state.period_start_ts is not None:
+            idx = self.game_state.current_period_index
+            self.game_state.period_elapsed[idx] += int(now_ts() - self.game_state.period_start_ts)
+            self.game_state.period_start_ts = None
+
         self.game_state.paused = True
 
     def resume_game(self) -> None:
-        """
-        Resume the game timer.
-        
-        Continues game timing from where it was paused.
-        """
+        """Resume the game after a pause without resetting the period."""
+
+        if self.game_state.game_start_ts is None:
+            self.start_game()
+            return
+
         self.game_state.paused = False
+        if self.game_state.period_start_ts is None:
+            self.game_state.period_start_ts = now_ts()
 
     def reset_game(self) -> None:
-        """
-        Reset the game to initial state.
-        
-        Clears all timing data and returns to pre-game state.
-        """
+        """Reset all timer state while keeping the roster intact."""
+
         self.game_state.game_start_ts = None
         self.game_state.scheduled_start_ts = None
         self.game_state.paused = True
         self.game_state.halftime_started = False
         self.game_state.halftime_end_ts = None
         self.game_state.elapsed_adjustment = 0
+        self.game_state.period_start_ts = None
+        self.game_state.current_period_index = 0
+        self.game_state.period_elapsed = [0] * self.game_state.period_count
+        self.game_state.period_adjustments = [0] * self.game_state.period_count
+        self.game_state.period_stoppage = [0] * self.game_state.period_count
 
     def start_halftime(self) -> None:
-        """
-        Begin halftime period.
-        
-        Sets halftime flag and calculates when halftime should end.
-        """
+        """Begin an interval break (halftime/quarter break)."""
+
+        if self.game_state.halftime_started:
+            return
+
+        if self.game_state.period_start_ts is not None:
+            idx = self.game_state.current_period_index
+            self.game_state.period_elapsed[idx] += int(now_ts() - self.game_state.period_start_ts)
+            self.game_state.period_start_ts = None
+
         current_time = now_ts()
         self.game_state.halftime_started = True
-        self.game_state.halftime_end_ts = current_time + (HALFTIME_PAUSE_MIN * 60)
+        self.game_state.halftime_end_ts = current_time + int(HALFTIME_PAUSE_MIN * 60)
         self.game_state.paused = True
 
     def end_halftime(self) -> None:
-        """
-        End halftime period and resume the game.
-        
-        Clears halftime flags and resumes game timing.
-        """
+        """End the break period and start the next period if available."""
+
+        if not self.game_state.halftime_started:
+            return
+
         self.game_state.halftime_started = False
         self.game_state.halftime_end_ts = None
-        self.game_state.paused = False
 
-    def add_time_adjustment(self, seconds: int) -> None:
-        """
-        Add manual time adjustment (stoppage time, corrections).
-        
-        Args:
-            seconds: Seconds to add (can be negative for corrections)
-        """
-        self.game_state.elapsed_adjustment += seconds
+        if self.game_state.current_period_index < self.game_state.period_count - 1:
+            self.game_state.current_period_index += 1
+
+        self.game_state.paused = False
+        self.game_state.period_start_ts = now_ts()
+        if self.game_state.game_start_ts is None:
+            self.game_state.game_start_ts = self.game_state.period_start_ts
+
+    # ------------------------------------------------------------------
+    # Adjustment APIs
+    # ------------------------------------------------------------------
+    def add_time_adjustment(
+        self,
+        seconds: int,
+        period_index: Optional[int] = None,
+        apply_to_all: bool = False,
+    ) -> None:
+        """Apply a manual correction to one or more periods."""
+
+        if seconds == 0:
+            return
+
+        self.game_state.ensure_timer_lists()
+        if apply_to_all:
+            targets = range(self.game_state.period_count)
+        else:
+            idx = (
+                period_index
+                if period_index is not None
+                else self.game_state.current_period_index
+            )
+            idx = max(0, min(idx, self.game_state.period_count - 1))
+            targets = [idx]
+
+        for idx in targets:
+            self.game_state.period_adjustments[idx] += seconds
+
+        self.game_state.elapsed_adjustment = sum(
+            self.game_state.period_adjustments[: self.game_state.period_count]
+        )
+
+    def add_stoppage_time(self, seconds: int, period_index: Optional[int] = None) -> None:
+        """Track stoppage/injury time for the specified period."""
+
+        if seconds == 0:
+            return
+
+        self.game_state.ensure_timer_lists()
+        idx = (
+            period_index
+            if period_index is not None
+            else self.game_state.current_period_index
+        )
+        idx = max(0, min(idx, self.game_state.period_count - 1))
+
+        new_value = self.game_state.period_stoppage[idx] + seconds
+        self.game_state.period_stoppage[idx] = max(0, new_value)
+
+    # ------------------------------------------------------------------
+    # Query helpers
+    # ------------------------------------------------------------------
+    def get_timer_configuration(self) -> Dict[str, object]:
+        """Return the current timer configuration for display purposes."""
+
+        self.game_state.ensure_timer_lists()
+        return {
+            "game_length_seconds": self.game_state.game_length_seconds,
+            "game_length_minutes": self.game_state.game_length_seconds // 60,
+            "period_count": self.game_state.period_count,
+            "period_lengths": self._get_period_lengths(),
+            "total_stoppage_seconds": self._get_total_stoppage_seconds(),
+            "total_adjustment_seconds": sum(
+                self.game_state.period_adjustments[: self.game_state.period_count]
+            ),
+        }
+
+    def get_period_summaries(self) -> List[Dict[str, int]]:
+        """Return elapsed/adjustment data for each period."""
+
+        self.game_state.ensure_timer_lists()
+        summaries: List[Dict[str, int]] = []
+        period_lengths = self._get_period_lengths()
+        now = now_ts()
+
+        for idx in range(self.game_state.period_count):
+            running = 0
+            if (
+                idx == self.game_state.current_period_index
+                and self.game_state.period_start_ts is not None
+                and not self.game_state.paused
+            ):
+                running = int(now - self.game_state.period_start_ts)
+
+            summaries.append(
+                {
+                    "index": idx,
+                    "number": idx + 1,
+                    "length_seconds": period_lengths[idx],
+                    "elapsed_seconds": self.game_state.period_elapsed[idx] + running,
+                    "adjustment_seconds": self.game_state.period_adjustments[idx],
+                    "stoppage_seconds": self.game_state.period_stoppage[idx],
+                }
+            )
+
+        return summaries
 
     def get_game_elapsed_seconds(self) -> int:
-        """
-        Get total elapsed game time in seconds.
-        
-        Returns:
-            Elapsed seconds including adjustments, or 0 if game not started
-        """
+        """Get total elapsed game time including adjustments and stoppage."""
+
         if self.game_state.game_start_ts is None:
             return 0
 
-        current_time = now_ts()
-        elapsed = int(current_time - self.game_state.game_start_ts)
-        
-        # Add manual adjustments
-        elapsed += self.game_state.elapsed_adjustment
-        
-        return max(0, elapsed)  # Never negative
+        self.game_state.ensure_timer_lists()
+        base_elapsed = self._get_base_elapsed_seconds()
+        adjustments = sum(self.game_state.period_adjustments[: self.game_state.period_count])
+        stoppage = self._get_total_stoppage_seconds()
+        return max(0, base_elapsed + adjustments + stoppage)
 
     def get_remaining_seconds(self) -> int:
-        """
-        Get remaining game time in seconds.
-        
-        Returns:
-            Remaining seconds, or full game length if not started
-        """
-        total_game_seconds = GAME_LENGTH_MIN * 60
-        elapsed = self.get_game_elapsed_seconds()
-        return max(0, total_game_seconds - elapsed)
+        """Get remaining game time including configured stoppage."""
+
+        if self.game_state.game_start_ts is None:
+            return self.game_state.game_length_seconds
+
+        self.game_state.ensure_timer_lists()
+        total_elapsed = self.get_game_elapsed_seconds()
+        target = self.game_state.game_length_seconds + self._get_total_stoppage_seconds()
+        return max(0, target - total_elapsed)
 
     def is_game_over(self) -> bool:
-        """
-        Check if game time has expired.
-        
-        Returns:
-            True if game time has elapsed
-        """
+        """Return True when the configured game time has fully elapsed."""
+
         return self.get_remaining_seconds() == 0
 
     def get_half_info(self) -> Tuple[int, bool]:
-        """
-        Get current half information.
-        
-        Returns:
-            Tuple of (current_half, is_halftime)
-            current_half: 1 or 2
-            is_halftime: True if currently in halftime break
-        """
-        if self.game_state.halftime_started:
-            return (1, True)
-        
-        elapsed = self.get_game_elapsed_seconds()
-        half_time_seconds = (GAME_LENGTH_MIN * 60) // 2
-        
-        if elapsed <= half_time_seconds:
-            return (1, False)
-        else:
-            return (2, False)
+        """Return the active period number and whether the timer is in a break."""
+
+        period_number = min(self.game_state.current_period_index + 1, self.game_state.period_count)
+        return (period_number, self.game_state.halftime_started)
 
     def should_suggest_halftime(self) -> bool:
-        """
-        Check if halftime should be suggested based on elapsed time.
-        
-        Returns:
-            True if first half is complete and halftime hasn't started
-        """
+        """Determine whether a period break should be suggested."""
+
+        self.game_state.ensure_timer_lists()
         if self.game_state.halftime_started:
             return False
-            
-        elapsed = self.get_game_elapsed_seconds()
-        half_time_seconds = (GAME_LENGTH_MIN * 60) // 2
-        
-        return elapsed >= half_time_seconds
+
+        if self.game_state.current_period_index >= self.game_state.period_count - 1:
+            return False
+
+        elapsed = self._get_current_period_elapsed_seconds(include_running=True)
+        target = self._get_period_target_seconds(self.game_state.current_period_index)
+        return elapsed >= target
 
     def get_halftime_remaining_seconds(self) -> Optional[int]:
-        """
-        Get remaining halftime seconds.
-        
-        Returns:
-            Remaining halftime seconds, or None if not in halftime
-        """
+        """Return remaining break seconds when in halftime."""
+
         if not self.game_state.halftime_started or self.game_state.halftime_end_ts is None:
             return None
-            
-        current_time = now_ts()
-        remaining = int(self.game_state.halftime_end_ts - current_time)
+
+        remaining = int(self.game_state.halftime_end_ts - now_ts())
         return max(0, remaining)
 
     def is_halftime_over(self) -> bool:
-        """
-        Check if halftime period has expired.
-        
-        Returns:
-            True if halftime time has elapsed
-        """
+        """Return True when the current break period has finished."""
+
         remaining = self.get_halftime_remaining_seconds()
         return remaining is not None and remaining == 0
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _get_period_lengths(self) -> List[int]:
+        base, remainder = divmod(self.game_state.game_length_seconds, self.game_state.period_count)
+        lengths = [base] * self.game_state.period_count
+        for idx in range(remainder):
+            lengths[idx] += 1
+        return lengths
+
+    def _get_total_stoppage_seconds(self) -> int:
+        return sum(self.game_state.period_stoppage[: self.game_state.period_count])
+
+    def _get_base_elapsed_seconds(self) -> int:
+        self.game_state.ensure_timer_lists()
+        total = sum(self.game_state.period_elapsed[: self.game_state.period_count])
+        if (
+            self.game_state.period_start_ts is not None
+            and not self.game_state.paused
+        ):
+            total += int(now_ts() - self.game_state.period_start_ts)
+        elif total == 0 and self.game_state.game_start_ts is not None:
+            total = max(0, int(now_ts() - self.game_state.game_start_ts))
+        return total
+
+    def _get_current_period_elapsed_seconds(self, *, include_running: bool) -> int:
+        idx = min(self.game_state.current_period_index, self.game_state.period_count - 1)
+        elapsed = self.game_state.period_elapsed[idx]
+        if (
+            include_running
+            and self.game_state.period_start_ts is not None
+            and not self.game_state.paused
+        ):
+            elapsed += int(now_ts() - self.game_state.period_start_ts)
+        return elapsed
+
+    def _get_period_target_seconds(self, period_index: int) -> int:
+        self.game_state.ensure_timer_lists()
+        lengths = self._get_period_lengths()
+        adj = self.game_state.period_adjustments[period_index]
+        stop = self.game_state.period_stoppage[period_index]
+        return lengths[period_index] + adj + stop

--- a/src/ui/tkinter_app.py
+++ b/src/ui/tkinter_app.py
@@ -8,12 +8,47 @@ import tkinter as tk
 from tkinter import ttk, messagebox, filedialog, simpledialog
 from typing import Dict, List, Tuple, Optional
 
-from ..models import Player, GameState
-from ..services import PersistenceService, TimerService
+from ..models import GameState, Player
+from ..services import AnalyticsService, PersistenceService, TimerService
 from ..utils import (
-    fmt_mmss, now_ts, APP_TITLE, POSITIONS, POS_SHORT_TO_FULL,
-    EQUAL_TIME_TARGET_MIN, GAME_LENGTH_MIN
+    fmt_mmss,
+    now_ts,
+    APP_TITLE,
+    POSITIONS,
+    POS_SHORT_TO_FULL,
+    GAME_LENGTH_MIN,
+    MIN_GAME_LENGTH_MIN,
+    MAX_GAME_LENGTH_MIN,
+    MIN_PERIOD_COUNT,
+    MAX_PERIOD_COUNT,
+    PERIOD_LABELS,
 )
+
+
+def fmt_signed_mmss(seconds: int) -> str:
+    """Format seconds as signed MM:SS string."""
+
+    sign = "+" if seconds >= 0 else "-"
+    return f"{sign}{fmt_mmss(abs(seconds))}"
+
+
+def ordinal(n: int) -> str:
+    """Return an ordinal string (1st, 2nd, …)."""
+
+    if 10 <= (n % 100) <= 20:
+        suffix = "th"
+    else:
+        suffix = {1: "st", 2: "nd", 3: "rd"}.get(n % 10, "th")
+    return f"{n}{suffix}"
+
+
+def describe_period(number: int, total: int) -> str:
+    """Return a human-friendly period label based on total periods."""
+
+    base = PERIOD_LABELS.get(total, "Period")
+    if total <= 1:
+        return base
+    return f"{ordinal(number)} {base}"
 
 
 class SidelineApp(tk.Tk):
@@ -25,6 +60,7 @@ class SidelineApp(tk.Tk):
         self.geometry("1120x680")
         self.state = GameState()
         self.timer_service = TimerService(self.state)
+        self.analytics_service = AnalyticsService(self.state, self.timer_service)
         self.sub_queue: List[Tuple[str, str]] = []  # (out_name, in_name) queued
         self.after_timer = None
 
@@ -44,14 +80,22 @@ class SidelineApp(tk.Tk):
         mbar.add_cascade(label="File", menu=filem)
 
         gamem = tk.Menu(mbar, tearoff=0)
+        gamem.add_command(label="Configure Timer…", command=self.configure_timer)
+        gamem.add_separator()
         gamem.add_command(label="Start / Resume", command=self.start_game)
         gamem.add_command(label="Pause", command=self.pause_game)
         gamem.add_command(label="Start Halftime (10.5m)", command=self.start_halftime)
         gamem.add_command(label="Force End Halftime", command=self.end_halftime)
         gamem.add_separator()
         gamem.add_command(label="Set Scheduled Start…", command=self.set_scheduled_start)
-        gamem.add_command(label="Adjust Elapsed (+/- sec)…", command=self.adjust_elapsed)
+        gamem.add_command(label="Manual Time Tools…", command=self.open_time_tools)
         mbar.add_cascade(label="Game", menu=gamem)
+
+        reportsm = tk.Menu(mbar, tearoff=0)
+        reportsm.add_command(
+            label="Playing Time Report", command=self.show_reports
+        )
+        mbar.add_cascade(label="Reports", menu=reportsm)
 
         self.config(menu=mbar)
 
@@ -60,7 +104,7 @@ class SidelineApp(tk.Tk):
         self.container.pack(fill="both", expand=True)
         self.frames: Dict[str, tk.Frame] = {}
 
-        for FrameClass in (HomeView, LineupView, GameView):
+        for FrameClass in (HomeView, LineupView, GameView, ReportsView):
             frame = FrameClass(self.container, self)
             self.frames[FrameClass.__name__] = frame
             frame.grid(row=0, column=0, sticky="nsew")
@@ -77,6 +121,9 @@ class SidelineApp(tk.Tk):
     def show_game(self):
         self._show_frame("GameView")
 
+    def show_reports(self):
+        self._show_frame("ReportsView")
+
     def _show_frame(self, frame_name: str):
         frame = self.frames[frame_name]
         frame.tkraise()
@@ -92,6 +139,7 @@ class SidelineApp(tk.Tk):
     def _apply_new_roster(self, players: List[Player]):
         self.state = GameState(roster={p.name: p for p in players})
         self.timer_service = TimerService(self.state)
+        self.analytics_service = AnalyticsService(self.state, self.timer_service)
         self.sub_queue.clear()
         self.show_home()
 
@@ -121,6 +169,7 @@ class SidelineApp(tk.Tk):
         try:
             self.state = PersistenceService.load_game_from_file(path)
             self.timer_service = TimerService(self.state)
+            self.analytics_service = AnalyticsService(self.state, self.timer_service)
             self.sub_queue.clear()
             self.show_home()
             messagebox.showinfo(APP_TITLE, "Game loaded.")
@@ -154,11 +203,40 @@ class SidelineApp(tk.Tk):
             except ValueError:
                 messagebox.showerror(APP_TITLE, "Invalid timestamp format")
 
-    def adjust_elapsed(self):
-        result = simpledialog.askinteger(APP_TITLE, "Adjust elapsed time by seconds (+/-):")
-        if result is not None:
-            self.timer_service.add_time_adjustment(result)
+    def configure_timer(self):
+        config = self.timer_service.get_timer_configuration()
+        dialog = TimerConfigDialog(self, config)
+        if dialog.result:
+            try:
+                self.timer_service.configure_game(
+                    game_length_minutes=dialog.result["minutes"],
+                    period_count=dialog.result["periods"],
+                )
+                messagebox.showinfo(APP_TITLE, "Timer configuration updated.")
+            except ValueError as exc:
+                messagebox.showerror(APP_TITLE, str(exc))
+        self.refresh_tables()
+
+    def open_time_tools(self):
+        dialog = TimeAdjustmentDialog(self, self.timer_service)
+        result = dialog.result
+        if not result:
+            return
+
+        try:
+            if result["mode"] == "adjustment":
+                self.timer_service.add_time_adjustment(
+                    result["seconds"],
+                    period_index=result["period_index"],
+                    apply_to_all=result["apply_to_all"],
+                )
+            else:
+                self.timer_service.add_stoppage_time(
+                    result["seconds"], period_index=result["period_index"]
+                )
             self.refresh_tables()
+        except ValueError as exc:
+            messagebox.showerror(APP_TITLE, str(exc))
 
     # ---------- Substitution Management ---------- #
     def queue_sub(self, out_name: str, in_name: str):
@@ -225,7 +303,7 @@ class SidelineApp(tk.Tk):
 
 class RosterDialog(tk.Toplevel):
     """Dialog for creating/editing team roster."""
-    
+
     def __init__(self, parent):
         super().__init__(parent)
         self.parent = parent
@@ -289,10 +367,275 @@ class RosterDialog(tk.Toplevel):
             
         except Exception as e:
             messagebox.showerror("Error", f"Failed to parse roster: {e}")
-    
+
     def _cancel(self):
         self.destroy()
 
+
+class TimerConfigDialog(simpledialog.Dialog):
+    """Dialog for configuring regulation length and period count."""
+
+    def __init__(self, parent: tk.Tk, config: Dict[str, object]):
+        self.config = config
+        minutes = int(config.get("game_length_minutes", GAME_LENGTH_MIN))
+        periods = int(config.get("period_count", 2))
+        self.minutes_var = tk.IntVar(value=max(MIN_GAME_LENGTH_MIN, minutes))
+        self.periods_var = tk.IntVar(value=max(MIN_PERIOD_COUNT, periods))
+        self.result: Optional[Dict[str, int]] = None
+        super().__init__(parent, title="Configure Game Timer")
+
+    def body(self, master):  # type: ignore[override]
+        frame = ttk.Frame(master)
+        frame.pack(fill="both", expand=True, padx=10, pady=10)
+
+        ttk.Label(frame, text="Regulation length (minutes):").grid(row=0, column=0, sticky="w")
+        minutes_spin = ttk.Spinbox(
+            frame,
+            from_=MIN_GAME_LENGTH_MIN,
+            to=MAX_GAME_LENGTH_MIN,
+            textvariable=self.minutes_var,
+            width=6,
+            increment=5,
+        )
+        minutes_spin.grid(row=0, column=1, sticky="w")
+
+        ttk.Label(frame, text="Number of periods:").grid(row=1, column=0, sticky="w", pady=(6, 0))
+        periods_spin = ttk.Spinbox(
+            frame,
+            from_=MIN_PERIOD_COUNT,
+            to=MAX_PERIOD_COUNT,
+            textvariable=self.periods_var,
+            width=6,
+        )
+        periods_spin.grid(row=1, column=1, sticky="w", pady=(6, 0))
+
+        self.summary_label = ttk.Label(frame, text="", padding=(0, 6, 0, 0))
+        self.summary_label.grid(row=2, column=0, columnspan=2, sticky="w")
+
+        ttk.Label(
+            frame,
+            text=(
+                f"Allowed: {MIN_GAME_LENGTH_MIN}-{MAX_GAME_LENGTH_MIN} minutes, "
+                f"{MIN_PERIOD_COUNT}-{MAX_PERIOD_COUNT} periods"
+            ),
+            foreground="gray",
+        ).grid(row=3, column=0, columnspan=2, sticky="w")
+
+        frame.columnconfigure(1, weight=1)
+
+        self.minutes_var.trace_add("write", lambda *_: self._update_preview())
+        self.periods_var.trace_add("write", lambda *_: self._update_preview())
+        self._update_preview()
+        return frame
+
+    def validate(self) -> bool:
+        minutes = self.minutes_var.get()
+        periods = self.periods_var.get()
+
+        if not (MIN_GAME_LENGTH_MIN <= minutes <= MAX_GAME_LENGTH_MIN):
+            messagebox.showerror(
+                APP_TITLE,
+                f"Minutes must be between {MIN_GAME_LENGTH_MIN} and {MAX_GAME_LENGTH_MIN}.",
+            )
+            return False
+
+        if not (MIN_PERIOD_COUNT <= periods <= MAX_PERIOD_COUNT):
+            messagebox.showerror(
+                APP_TITLE,
+                f"Periods must be between {MIN_PERIOD_COUNT} and {MAX_PERIOD_COUNT}.",
+            )
+            return False
+
+        if minutes * 60 < periods * 60:
+            messagebox.showerror(APP_TITLE, "Provide at least one minute per period.")
+            return False
+
+        self.result = {"minutes": minutes, "periods": periods}
+        return True
+
+    def apply(self) -> None:  # type: ignore[override]
+        # Result already stored during validation
+        pass
+
+    def _update_preview(self) -> None:
+        minutes = max(MIN_GAME_LENGTH_MIN, int(self.minutes_var.get() or MIN_GAME_LENGTH_MIN))
+        periods = max(MIN_PERIOD_COUNT, int(self.periods_var.get() or MIN_PERIOD_COUNT))
+        total_seconds = minutes * 60
+        base, remainder = divmod(total_seconds, periods)
+        lengths = [base + (1 if i < remainder else 0) for i in range(periods)]
+        label = PERIOD_LABELS.get(periods, "Period")
+        plural = label if periods == 1 else f"{label}s"
+        segments = ", ".join(fmt_mmss(value) for value in lengths)
+        self.summary_label.config(
+            text=(
+                f"Regulation total {fmt_mmss(total_seconds)} — {periods} {plural}: {segments}"
+            )
+        )
+
+
+class TimeAdjustmentDialog(simpledialog.Dialog):
+    """Dialog for manual adjustments and stoppage tracking."""
+
+    MODE_LABELS = {
+        "adjustment": "Manual Adjustment (+/-)",
+        "stoppage": "Stoppage / Injury Time",
+    }
+
+    def __init__(self, parent: tk.Tk, timer_service: TimerService):
+        self.timer_service = timer_service
+        self.config = timer_service.get_timer_configuration()
+        self.period_summaries = timer_service.get_period_summaries()
+        current_period, _ = timer_service.get_half_info()
+        self.mode_choice_var = tk.StringVar(value=self.MODE_LABELS["adjustment"])
+        self.seconds_var = tk.StringVar(value="0")
+        self.period_var = tk.StringVar()
+        self.apply_all_var = tk.BooleanVar(value=False)
+        self.result: Optional[Dict[str, object]] = None
+
+        period_labels = [
+            describe_period(summary["number"], self.config["period_count"])
+            for summary in self.period_summaries
+        ]
+        if period_labels:
+            default_idx = min(current_period - 1, len(period_labels) - 1)
+            self.period_var.set(period_labels[default_idx])
+        self._period_label_map = dict(zip(period_labels, [s["index"] for s in self.period_summaries]))
+
+        super().__init__(parent, title="Manual Time Tools")
+
+    def body(self, master):  # type: ignore[override]
+        frame = ttk.Frame(master)
+        frame.pack(fill="both", expand=True, padx=10, pady=10)
+
+        ttk.Label(frame, text="Current periods:").grid(row=0, column=0, columnspan=2, sticky="w")
+
+        tree = ttk.Treeview(
+            frame,
+            columns=("Reg", "Elapsed", "Adj", "Stop"),
+            show="headings",
+            height=max(3, len(self.period_summaries)),
+        )
+        tree.heading("Reg", text="Reg")
+        tree.heading("Elapsed", text="Elapsed")
+        tree.heading("Adj", text="Adjust")
+        tree.heading("Stop", text="Stoppage")
+        tree.column("Reg", width=90, anchor="center")
+        tree.column("Elapsed", width=90, anchor="center")
+        tree.column("Adj", width=90, anchor="center")
+        tree.column("Stop", width=90, anchor="center")
+        tree.grid(row=1, column=0, columnspan=2, sticky="nsew", pady=(4, 8))
+
+        lengths = self.config.get("period_lengths", [])
+        current_index = self.timer_service.game_state.current_period_index
+        for summary in self.period_summaries:
+            idx = summary["index"]
+            values = (
+                fmt_mmss(lengths[idx]) if idx < len(lengths) else fmt_mmss(0),
+                fmt_mmss(summary["elapsed_seconds"]),
+                fmt_signed_mmss(summary["adjustment_seconds"]),
+                fmt_mmss(summary["stoppage_seconds"]),
+            )
+            tags = ("active",) if idx == current_index else ()
+            tree.insert("", "end", values=values, tags=tags)
+        tree.tag_configure("active", font=("Arial", 9, "bold"))
+
+        ttk.Label(
+            frame,
+            text=(
+                f"Total stoppage: {fmt_mmss(self.config['total_stoppage_seconds'])}    "
+                f"Total adjustments: {fmt_signed_mmss(self.config['total_adjustment_seconds'])}"
+            ),
+            foreground="gray",
+        ).grid(row=2, column=0, columnspan=2, sticky="w")
+
+        ttk.Label(frame, text="Action:").grid(row=3, column=0, sticky="w", pady=(8, 0))
+        self.mode_combo = ttk.Combobox(
+            frame,
+            state="readonly",
+            values=list(self.MODE_LABELS.values()),
+            textvariable=self.mode_choice_var,
+        )
+        self.mode_combo.grid(row=3, column=1, sticky="we", pady=(8, 0))
+
+        ttk.Label(frame, text="Seconds:").grid(row=4, column=0, sticky="w", pady=(6, 0))
+        self.seconds_entry = ttk.Entry(frame, textvariable=self.seconds_var)
+        self.seconds_entry.grid(row=4, column=1, sticky="we", pady=(6, 0))
+
+        ttk.Label(frame, text="Period:").grid(row=5, column=0, sticky="w", pady=(6, 0))
+        self.period_combo = ttk.Combobox(
+            frame,
+            state="readonly",
+            values=list(self._period_label_map.keys()),
+            textvariable=self.period_var,
+        )
+        self.period_combo.grid(row=5, column=1, sticky="we", pady=(6, 0))
+
+        self.apply_all_check = ttk.Checkbutton(
+            frame,
+            text="Apply to all periods",
+            variable=self.apply_all_var,
+        )
+        self.apply_all_check.grid(row=6, column=0, columnspan=2, sticky="w", pady=(6, 0))
+
+        self.hint_label = ttk.Label(frame, text="", foreground="gray")
+        self.hint_label.grid(row=7, column=0, columnspan=2, sticky="w", pady=(4, 0))
+
+        frame.columnconfigure(1, weight=1)
+        frame.rowconfigure(1, weight=1)
+
+        self.mode_combo.bind("<<ComboboxSelected>>", lambda *_: self._on_mode_change())
+        self._on_mode_change()
+        return frame
+
+    def validate(self) -> bool:
+        mode = self._selected_mode()
+        try:
+            seconds = int(self.seconds_var.get())
+        except (TypeError, ValueError):
+            messagebox.showerror(APP_TITLE, "Enter time in whole seconds.")
+            return False
+
+        if mode == "adjustment" and seconds == 0:
+            messagebox.showerror(APP_TITLE, "Adjustment must be a non-zero value.")
+            return False
+
+        if mode == "stoppage" and seconds <= 0:
+            messagebox.showerror(APP_TITLE, "Stoppage time must be positive seconds.")
+            return False
+
+        period_label = self.period_var.get()
+        if period_label not in self._period_label_map:
+            messagebox.showerror(APP_TITLE, "Select a period to update.")
+            return False
+
+        period_index = self._period_label_map[period_label]
+        self.result = {
+            "mode": mode,
+            "seconds": seconds,
+            "period_index": period_index,
+            "apply_to_all": bool(self.apply_all_var.get()) if mode == "adjustment" else False,
+        }
+        return True
+
+    def apply(self) -> None:  # type: ignore[override]
+        # Result stored during validation
+        pass
+
+    def _selected_mode(self) -> str:
+        for key, value in self.MODE_LABELS.items():
+            if value == self.mode_choice_var.get():
+                return key
+        return "adjustment"
+
+    def _on_mode_change(self) -> None:
+        mode = self._selected_mode()
+        if mode == "stoppage":
+            self.apply_all_var.set(False)
+            self.apply_all_check.state(["disabled"])
+            self.hint_label.config(text="Stoppage time adds extra playable seconds (positive only).")
+        else:
+            self.apply_all_check.state(["!disabled"])
+            self.hint_label.config(text="Adjustments can be positive or negative (affects elapsed clock).")
 
 class HomeView(ttk.Frame):
     """Home/overview page showing game status and player summary."""
@@ -308,16 +651,19 @@ class HomeView(ttk.Frame):
         # Game status frame
         status_frame = ttk.LabelFrame(self, text="Game Status", padding=10)
         status_frame.pack(fill="x", padx=10, pady=5)
-        
+
         self.status_label = ttk.Label(status_frame, text="Game not started")
         self.status_label.pack()
+        self.detail_label = ttk.Label(status_frame, text="", foreground="gray")
+        self.detail_label.pack()
         
         # Quick controls
         controls_frame = ttk.Frame(self)
         controls_frame.pack(pady=10)
-        
+
         ttk.Button(controls_frame, text="Lineup", command=self.controller.show_lineup).pack(side="left", padx=5)
         ttk.Button(controls_frame, text="Game View", command=self.controller.show_game).pack(side="left", padx=5)
+        ttk.Button(controls_frame, text="Reports", command=self.controller.show_reports).pack(side="left", padx=5)
         
         # Player summary
         summary_frame = ttk.LabelFrame(self, text="Player Summary", padding=10)
@@ -343,15 +689,35 @@ class HomeView(ttk.Frame):
 
     def refresh(self):
         # Update status
+        config = self.controller.timer_service.get_timer_configuration()
+        target_seconds = config["game_length_seconds"] + config["total_stoppage_seconds"]
+
         if self.controller.state.game_start_ts:
             elapsed = self.controller.timer_service.get_game_elapsed_seconds()
             remaining = self.controller.timer_service.get_remaining_seconds()
-            status = f"Game Time: {fmt_mmss(elapsed)} / Remaining: {fmt_mmss(remaining)}"
+            status = f"Elapsed {fmt_mmss(elapsed)} / Target {fmt_mmss(target_seconds)} (Remaining {fmt_mmss(remaining)})"
             if self.controller.state.paused:
                 status += " (PAUSED)"
+            period_number, in_break = self.controller.timer_service.get_half_info()
+            period_text = describe_period(period_number, config["period_count"])
+            detail = [f"{period_text} ({period_number}/{config['period_count']})"]
+            if in_break:
+                detail.append("Break in progress")
+            detail.append(f"Stoppage {fmt_mmss(config['total_stoppage_seconds'])}")
+            detail.append(f"Adjust {fmt_signed_mmss(config['total_adjustment_seconds'])}")
+            self.detail_label.config(text=" • ".join(detail))
         else:
             status = "Game not started"
-            
+            lengths = config.get("period_lengths", [])
+            if not lengths:
+                lengths = [config["game_length_seconds"]]
+            plural_label = PERIOD_LABELS.get(config["period_count"], "Period")
+            plural = plural_label if config["period_count"] == 1 else f"{plural_label}s"
+            periods_summary = ", ".join(fmt_mmss(value) for value in lengths)
+            self.detail_label.config(
+                text=f"Configured: {config['period_count']} {plural} ({periods_summary})"
+            )
+
         self.status_label.config(text=status)
         
         # Update player summary
@@ -444,25 +810,54 @@ class GameView(ttk.Frame):
         # Header with game controls
         header_frame = ttk.Frame(self)
         header_frame.pack(fill="x", padx=10, pady=5)
-        
+
         ttk.Button(header_frame, text="← Back to Home", command=self.controller.show_home).pack(side="left")
-        
+
         # Game timer display
         self.timer_label = ttk.Label(header_frame, text="00:00", font=("Arial", 20, "bold"))
         self.timer_label.pack(side="right")
-        
+        self.period_label = ttk.Label(header_frame, text="Not Started", font=("Arial", 12))
+        self.period_label.pack(side="right", padx=(0, 12))
+
         # Control buttons
         controls_frame = ttk.Frame(self)
         controls_frame.pack(fill="x", padx=10, pady=5)
-        
+
         ttk.Button(controls_frame, text="Start", command=self.controller.start_game).pack(side="left", padx=2)
         ttk.Button(controls_frame, text="Pause", command=self.controller.pause_game).pack(side="left", padx=2)
         ttk.Button(controls_frame, text="Halftime", command=self.controller.start_halftime).pack(side="left", padx=2)
-        
+
+        status_frame = ttk.Frame(self)
+        status_frame.pack(fill="x", padx=10, pady=(0, 5))
+        self.clock_meta_label = ttk.Label(status_frame, text="", foreground="gray")
+        self.clock_meta_label.pack(side="left")
+
+        period_frame = ttk.LabelFrame(self, text="Period Summary", padding=5)
+        period_frame.pack(fill="x", padx=10, pady=5)
+        self.period_tree = ttk.Treeview(
+            period_frame,
+            columns=("Period", "Reg", "Elapsed", "Adj", "Stop", "Remain"),
+            show="headings",
+            height=4,
+        )
+        headings = [
+            ("Period", 140),
+            ("Reg", 80),
+            ("Elapsed", 80),
+            ("Adj", 80),
+            ("Stop", 80),
+            ("Remain", 90),
+        ]
+        for name, width in headings:
+            self.period_tree.heading(name, text=name)
+            self.period_tree.column(name, width=width, anchor="center")
+        self.period_tree.pack(fill="x", expand=False)
+        self.period_tree.tag_configure("active", font=("Arial", 9, "bold"))
+
         # Substitution queue
         sub_frame = ttk.LabelFrame(self, text="Substitution Queue", padding=10)
         sub_frame.pack(fill="x", padx=10, pady=5)
-        
+
         self.sub_label = ttk.Label(sub_frame, text="No substitutions queued")
         self.sub_label.pack(side="left")
         
@@ -498,12 +893,54 @@ class GameView(ttk.Frame):
 
     def refresh(self):
         # Update timer display
+        config = self.controller.timer_service.get_timer_configuration()
+        report = self.controller.analytics_service.generate_game_report()
+        summary_lookup = {summary.name: summary for summary in report.players}
         if self.controller.state.game_start_ts:
             elapsed = self.controller.timer_service.get_game_elapsed_seconds()
             self.timer_label.config(text=fmt_mmss(elapsed))
         else:
             self.timer_label.config(text="00:00")
-        
+
+        target_seconds = config["game_length_seconds"] + config["total_stoppage_seconds"]
+        remaining_seconds = self.controller.timer_service.get_remaining_seconds()
+        meta_parts = [
+            f"Target {fmt_mmss(target_seconds)}",
+            f"Remaining {fmt_mmss(remaining_seconds)}",
+            f"Stoppage {fmt_mmss(config['total_stoppage_seconds'])}",
+            f"Adjust {fmt_signed_mmss(config['total_adjustment_seconds'])}",
+        ]
+        self.clock_meta_label.config(text=" • ".join(meta_parts))
+
+        period_number, in_break = self.controller.timer_service.get_half_info()
+        period_text = f"{describe_period(period_number, config['period_count'])} ({period_number}/{config['period_count']})"
+        if in_break:
+            period_text += " – Break"
+        self.period_label.config(text=period_text)
+
+        summaries = self.controller.timer_service.get_period_summaries()
+        self.period_tree.delete(*self.period_tree.get_children())
+        if summaries:
+            self.period_tree.configure(height=max(3, len(summaries)))
+        current_index = self.controller.timer_service.game_state.current_period_index
+        for summary in summaries:
+            target = (
+                summary["length_seconds"]
+                + summary["adjustment_seconds"]
+                + summary["stoppage_seconds"]
+            )
+            remain = max(0, target - summary["elapsed_seconds"])
+            values = (
+                describe_period(summary["number"], config["period_count"]),
+                fmt_mmss(summary["length_seconds"]),
+                fmt_mmss(summary["elapsed_seconds"]),
+                fmt_signed_mmss(summary["adjustment_seconds"]),
+                fmt_mmss(summary["stoppage_seconds"]),
+                fmt_mmss(remain),
+            )
+            tags = ("active",) if summary["index"] == current_index and not in_break else ()
+            self.period_tree.insert("", "end", values=values, tags=tags)
+
         # Update substitution queue display
         if self.controller.sub_queue:
             subs_text = ", ".join([f"{out} → {in_}" for out, in_ in self.controller.sub_queue])
@@ -523,24 +960,138 @@ class GameView(ttk.Frame):
         # Populate tables
         for player in self.controller.state.roster.values():
             total_time = player.total_seconds + player.current_stint_seconds(current_time)
-            
+            summary_data = summary_lookup.get(player.name)
+
             if player.on_field:
-                self.field_tree.insert("", "end", text=f"{player.name} #{player.number}", 
+                self.field_tree.insert("", "end", text=f"{player.name} #{player.number}",
                                      values=(player.position or "", fmt_mmss(total_time)))
             else:
                 # Color code based on fairness
                 fairness_color = ""
-                target_seconds = EQUAL_TIME_TARGET_MIN * 60
-                if total_time >= target_seconds:
-                    fairness_color = "green"
-                elif total_time < (target_seconds * 0.8):
-                    fairness_color = "red"
-                else:
-                    fairness_color = "orange"
-                
-                item = self.bench_tree.insert("", "end", text=f"{player.name} #{player.number}", 
+                if summary_data:
+                    if summary_data.fairness == "over":
+                        fairness_color = "red"
+                    elif summary_data.fairness == "under":
+                        fairness_color = "orange"
+                    else:
+                        fairness_color = "green"
+
+                item = self.bench_tree.insert("", "end", text=f"{player.name} #{player.number}",
                                             values=(fmt_mmss(total_time),))
                 # Note: Tkinter treeview color tagging would be implemented here in full version
+
+
+class ReportsView(ttk.Frame):
+    """Analytics view showing playing time distribution."""
+
+    def __init__(self, parent, controller):
+        super().__init__(parent)
+        self.controller = controller
+        self._build_ui()
+
+    def _build_ui(self):
+        header = ttk.Frame(self)
+        header.pack(fill="x", padx=10, pady=5)
+        ttk.Button(header, text="← Back to Home", command=self.controller.show_home).pack(side="left")
+        ttk.Label(header, text="Playing Time Analytics", font=("Arial", 16, "bold")).pack(side="left", padx=10)
+        ttk.Button(header, text="Go to Game", command=self.controller.show_game).pack(side="right")
+
+        summary_frame = ttk.LabelFrame(self, text="Summary", padding=10)
+        summary_frame.pack(fill="x", padx=10, pady=5)
+        self.summary_label = ttk.Label(summary_frame, text="No roster loaded.")
+        self.summary_label.pack(anchor="w")
+        self.detail_label = ttk.Label(summary_frame, text="", foreground="gray")
+        self.detail_label.pack(anchor="w")
+        self.distribution_label = ttk.Label(summary_frame, text="", foreground="gray")
+        self.distribution_label.pack(anchor="w")
+
+        tree_frame = ttk.LabelFrame(self, text="Player Breakdown", padding=10)
+        tree_frame.pack(fill="both", expand=True, padx=10, pady=5)
+        columns = ("Number", "Preferred", "Status", "Played", "Target", "Delta", "Share")
+        self.tree = ttk.Treeview(tree_frame, columns=columns, show="tree headings")
+        self.tree.heading("#0", text="Name")
+        self.tree.column("#0", width=180, anchor="w")
+        col_specs = {
+            "Number": (70, "center"),
+            "Preferred": (120, "center"),
+            "Status": (150, "center"),
+            "Played": (110, "center"),
+            "Target": (110, "center"),
+            "Delta": (90, "center"),
+            "Share": (80, "center"),
+        }
+        for column in columns:
+            self.tree.heading(column, text=column)
+            width, anchor = col_specs[column]
+            self.tree.column(column, width=width, anchor=anchor)
+        self.tree.pack(fill="both", expand=True)
+        self.tree.tag_configure("under", foreground="#ffb020")
+        self.tree.tag_configure("over", foreground="#ff6b6b")
+        self.tree.tag_configure("ok", foreground="#24c88b")
+
+        self.hint_label = ttk.Label(
+            self,
+            text="Delta compares live totals against an equal share of regulation + stoppage + adjustments.",
+            foreground="gray",
+        )
+        self.hint_label.pack(fill="x", padx=12, pady=(0, 10))
+
+    def on_show(self):
+        self.refresh()
+        self.controller.start_auto_refresh()
+
+    def refresh(self):
+        report = self.controller.analytics_service.generate_game_report()
+        if report.roster_size == 0:
+            self.summary_label.config(text="Add players to see analytics.")
+            self.detail_label.config(text="")
+            self.distribution_label.config(text="")
+            self.tree.delete(*self.tree.get_children())
+            return
+
+        summary_text = (
+            f"Elapsed {fmt_mmss(report.elapsed_seconds)} of "
+            f"{fmt_mmss(report.target_seconds_total)} target — {report.roster_size} players"
+        )
+        self.summary_label.config(text=summary_text)
+
+        details = [
+            f"Regulation {fmt_mmss(report.regulation_seconds)}",
+            f"Stoppage {fmt_mmss(report.stoppage_seconds)}",
+            f"Adjust {fmt_signed_mmss(report.adjustment_seconds)}",
+            f"Per Player {fmt_mmss(report.target_seconds_per_player)}",
+        ]
+        self.detail_label.config(text=" • ".join(details))
+
+        distribution = [
+            f"Average {fmt_mmss(int(round(report.average_seconds)))}",
+            f"Median {fmt_mmss(int(round(report.median_seconds)))}",
+            f"Range {fmt_mmss(report.min_seconds)}–{fmt_mmss(report.max_seconds)}",
+        ]
+        self.distribution_label.config(text=" • ".join(distribution))
+
+        self.tree.delete(*self.tree.get_children())
+        for summary in report.players:
+            status = "On Field" if summary.on_field else "Bench"
+            if summary.on_field and summary.position:
+                status += f" ({summary.position})"
+            preferred = ", ".join(summary.preferred_positions) or "—"
+            share = f"{summary.target_share * 100:.1f}%"
+            self.tree.insert(
+                "",
+                "end",
+                text=summary.name,
+                values=(
+                    summary.number or "",
+                    preferred,
+                    status,
+                    fmt_mmss(summary.cumulative_seconds),
+                    fmt_mmss(summary.target_seconds),
+                    fmt_signed_mmss(summary.delta_seconds),
+                    share,
+                ),
+                tags=(summary.fairness,),
+            )
 
 
 def create_tkinter_app() -> SidelineApp:

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -5,11 +5,35 @@ This package contains utility functions used throughout the application.
 """
 from .time_utils import fmt_mmss, now_ts
 from .constants import (
-    APP_TITLE, GAME_LENGTH_MIN, EQUAL_TIME_TARGET_MIN, 
-    HALFTIME_PAUSE_MIN, POSITIONS, POS_SHORT_TO_FULL
+    APP_TITLE,
+    GAME_LENGTH_MIN,
+    EQUAL_TIME_TARGET_MIN,
+    HALFTIME_PAUSE_MIN,
+    POSITIONS,
+    POS_SHORT_TO_FULL,
+    DEFAULT_GAME_LENGTH_MIN,
+    DEFAULT_PERIOD_COUNT,
+    MIN_GAME_LENGTH_MIN,
+    MAX_GAME_LENGTH_MIN,
+    MIN_PERIOD_COUNT,
+    MAX_PERIOD_COUNT,
+    PERIOD_LABELS,
 )
 
 __all__ = [
-    "fmt_mmss", "now_ts", "APP_TITLE", "GAME_LENGTH_MIN", 
-    "EQUAL_TIME_TARGET_MIN", "HALFTIME_PAUSE_MIN", "POSITIONS", "POS_SHORT_TO_FULL"
+    "fmt_mmss",
+    "now_ts",
+    "APP_TITLE",
+    "GAME_LENGTH_MIN",
+    "EQUAL_TIME_TARGET_MIN",
+    "HALFTIME_PAUSE_MIN",
+    "POSITIONS",
+    "POS_SHORT_TO_FULL",
+    "DEFAULT_GAME_LENGTH_MIN",
+    "DEFAULT_PERIOD_COUNT",
+    "MIN_GAME_LENGTH_MIN",
+    "MAX_GAME_LENGTH_MIN",
+    "MIN_PERIOD_COUNT",
+    "MAX_PERIOD_COUNT",
+    "PERIOD_LABELS",
 ]

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -7,16 +7,33 @@ This module contains configuration constants used throughout the application.
 # Application metadata
 APP_TITLE = "Sideline Timekeeper"
 
-# Game timing constants
-GAME_LENGTH_MIN = 60
+# Game timing defaults
+DEFAULT_GAME_LENGTH_MIN = 60
+DEFAULT_PERIOD_COUNT = 2
+MIN_GAME_LENGTH_MIN = 10
+MAX_GAME_LENGTH_MIN = 120
+MIN_PERIOD_COUNT = 1
+MAX_PERIOD_COUNT = 4
+
+# Friendly labels for different period counts (used for UI hints)
+PERIOD_LABELS = {
+    1: "Full Time",
+    2: "Half",
+    3: "Third",
+    4: "Quarter",
+}
+
+# Backward compatibility aliases – existing modules still import these names
+GAME_LENGTH_MIN = DEFAULT_GAME_LENGTH_MIN
+
 EQUAL_TIME_TARGET_MIN = 30
 HALFTIME_PAUSE_MIN = 10.5
 
 # Position configuration
 POSITIONS = ["GK", "DF", "DF", "DF", "MF", "MF", "ST", "ST", "ST"]  # required on-field slots
 POS_SHORT_TO_FULL = {
-    "GK": "Goalkeeper", 
-    "DF": "Defender", 
-    "MF": "Midfielder", 
+    "GK": "Goalkeeper",
+    "DF": "Defender",
+    "MF": "Midfielder",
     "ST": "Striker"
 }

--- a/tests/test_analytics_service.py
+++ b/tests/test_analytics_service.py
@@ -1,0 +1,52 @@
+"""Tests for analytics reporting."""
+
+import pytest
+
+from src.models import GameState, Player
+from src.services import AnalyticsService, TimerService
+
+
+def test_generate_game_report_produces_target_and_fairness():
+    state = GameState(
+        roster={
+            "Alice": Player(name="Alice", number="10", preferred="ST", total_seconds=480),
+            "Bob": Player(name="Bob", number="2", preferred="DF", total_seconds=120),
+        },
+        game_length_seconds=600,
+        period_count=2,
+        period_elapsed=[400, 0],
+        period_adjustments=[20, 0],
+        period_stoppage=[10, 0],
+        current_period_index=0,
+        game_start_ts=1,
+        paused=True,
+    )
+    state.ensure_timer_lists()
+
+    timer_service = TimerService(state)
+    analytics = AnalyticsService(state, timer_service)
+
+    report = analytics.generate_game_report()
+
+    assert report.roster_size == 2
+    assert report.regulation_seconds == 600
+    assert report.stoppage_seconds == 10
+    assert report.adjustment_seconds == 20
+    assert report.elapsed_seconds == 430
+    assert report.target_seconds_total == 630
+    assert report.target_seconds_per_player == 315
+
+    assert [summary.name for summary in report.players] == ["Bob", "Alice"]
+
+    players = {summary.name: summary for summary in report.players}
+    alice = players["Alice"]
+    bob = players["Bob"]
+
+    assert alice.fairness == "over"
+    assert alice.delta_seconds == 165
+    assert pytest.approx(alice.target_share, rel=1e-4) == alice.cumulative_seconds / report.target_seconds_per_player
+
+    assert bob.fairness == "under"
+    assert bob.delta_seconds == -195
+    assert pytest.approx(bob.target_share, rel=1e-4) == bob.cumulative_seconds / report.target_seconds_per_player
+    assert bob.bench_seconds == 310

--- a/tests/test_timer_service.py
+++ b/tests/test_timer_service.py
@@ -1,0 +1,98 @@
+import unittest
+from unittest.mock import patch
+
+from src.models import GameState
+from src.services import TimerService
+
+
+class TimerServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.state = GameState()
+        self.service = TimerService(self.state)
+
+    def test_configure_game_resets_periods(self) -> None:
+        self.service.configure_game(game_length_minutes=70, period_count=2)
+        self.assertEqual(self.state.game_length_seconds, 70 * 60)
+        self.assertEqual(self.state.period_count, 2)
+        self.assertEqual(self.state.period_elapsed, [0, 0])
+        self.assertEqual(self.state.period_adjustments, [0, 0])
+        self.assertEqual(self.state.period_stoppage, [0, 0])
+
+        with patch("src.services.timer_service.now_ts", return_value=1000):
+            self.service.start_game()
+
+        with self.assertRaises(ValueError):
+            self.service.configure_game(game_length_minutes=60)
+
+    def test_adjustments_and_stoppage_tracking(self) -> None:
+        self.service.configure_game(game_length_minutes=60, period_count=2)
+
+        self.service.add_time_adjustment(15)
+        self.assertEqual(self.state.period_adjustments, [15, 0])
+        self.assertEqual(self.state.elapsed_adjustment, 15)
+
+        self.service.add_time_adjustment(-5, period_index=1)
+        self.assertEqual(self.state.period_adjustments, [15, -5])
+        self.assertEqual(self.state.elapsed_adjustment, 10)
+
+        self.service.add_time_adjustment(10, apply_to_all=True)
+        self.assertEqual(self.state.period_adjustments, [25, 5])
+        self.assertEqual(self.state.elapsed_adjustment, 30)
+
+        self.service.add_stoppage_time(30)
+        self.assertEqual(self.state.period_stoppage[0], 30)
+        self.service.add_stoppage_time(-100, period_index=0)
+        self.assertEqual(self.state.period_stoppage[0], 0)
+
+    def test_elapsed_and_remaining_seconds(self) -> None:
+        self.service.configure_game(game_length_minutes=60, period_count=2)
+
+        with patch("src.services.timer_service.now_ts", return_value=1000):
+            self.service.start_game()
+
+        with patch("src.services.timer_service.now_ts", return_value=1600):
+            self.service.pause_game()
+
+        # 10 minutes regulation in first period
+        self.assertEqual(self.state.period_elapsed[0], 600)
+
+        self.service.add_time_adjustment(30)
+        self.service.add_stoppage_time(60)
+
+        self.assertEqual(self.service.get_game_elapsed_seconds(), 600 + 30 + 60)
+        expected_remaining = (60 * 60 + 60) - (600 + 30 + 60)
+        self.assertEqual(self.service.get_remaining_seconds(), expected_remaining)
+        self.assertFalse(self.service.should_suggest_halftime())
+
+        # Force suggestion by setting elapsed to target
+        config = self.service.get_timer_configuration()
+        target_first = config["period_lengths"][0] + self.state.period_adjustments[0] + self.state.period_stoppage[0]
+        self.state.period_elapsed[0] = target_first
+        self.assertTrue(self.service.should_suggest_halftime())
+
+        with patch("src.services.timer_service.now_ts", return_value=2000):
+            self.service.start_halftime()
+
+        self.assertTrue(self.state.halftime_started)
+        self.assertTrue(self.state.paused)
+
+        with patch("src.services.timer_service.now_ts", return_value=2100):
+            self.service.end_halftime()
+
+        self.assertEqual(self.state.current_period_index, 1)
+        self.assertFalse(self.state.paused)
+        self.assertFalse(self.state.halftime_started)
+        self.assertIsNotNone(self.state.period_start_ts)
+
+        with patch("src.services.timer_service.now_ts", return_value=2200):
+            summaries = self.service.get_period_summaries()
+
+        self.assertEqual(len(summaries), 2)
+        self.assertGreaterEqual(summaries[0]["elapsed_seconds"], self.state.period_elapsed[0])
+        refreshed_config = self.service.get_timer_configuration()
+        self.assertEqual(refreshed_config["period_count"], 2)
+        self.assertEqual(refreshed_config["total_stoppage_seconds"], sum(self.state.period_stoppage))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add analytics dataclasses and service to compute game reports
- expose the new analytics in both desktop and web interfaces with dedicated reports views
- cover the analytics logic with unit tests

## Testing
- `pytest`
- `python test_structure.py`
- `python -c "from src import *; print('All imports successful')"`


------
https://chatgpt.com/codex/tasks/task_b_68cebd5a896c8320ab7dff6c6dd2aa56