### PR TITLE
Update web server port to 7122

### DIFF
--- a/STRUCTURE_MIGRATION.md
+++ b/STRUCTURE_MIGRATION.md
@@ -49,7 +49,7 @@ python run_desktop.py
 **Web Application:**
 ```bash
 python run_web.py
-# Then open http://127.0.0.1:5000
+# Then open http://127.0.0.1:7122
 ```
 
 ### Legacy Entry Points (Backward Compatibility)
@@ -62,7 +62,7 @@ python coach_timer.py
 **Web Application:**
 ```bash
 python app.py
-# Then open http://127.0.0.1:5000
+# Then open http://127.0.0.1:7122
 ```
 
 ## What Changed

--- a/app.py
+++ b/app.py
@@ -18,7 +18,7 @@ try:
     if __name__ == "__main__":
         # Run web app serving files from the project root
         project_root = os.path.dirname(__file__)
-        run_web_app(host="127.0.0.1", port=5000, static_folder=project_root)
+        run_web_app(host="127.0.0.1", port=7122, static_folder=project_root)
         
 except ImportError:
     # Fallback to original implementation if new structure not available

--- a/src/ui/web_app.py
+++ b/src/ui/web_app.py
@@ -707,7 +707,7 @@ def create_app(static_folder: str = ".") -> Flask:
     return app
 
 
-def run_web_app(host: str = "127.0.0.1", port: int = 5000, static_folder: str = ".") -> None:
+def run_web_app(host: str = "127.0.0.1", port: int = 7122, static_folder: str = ".") -> None:
     """
     Run the web application.
     


### PR DESCRIPTION
## Summary
- update the Flask entry points so the web application binds to port 7122 by default
- refresh documentation references to the local development URL to reflect the new port

## Testing
- python test_structure.py
- python -c "from src import *; print('All imports successful')"
- python run_desktop.py *(fails: TclError no display name and no $DISPLAY environment variable)*
- python run_web.py
- python coach_timer.py *(fails: TclError no display name and no $DISPLAY environment variable)*
- python app.py

------
https://chatgpt.com/codex/tasks/task_b_68ceee4816388320b86551860e623334